### PR TITLE
Add *~ (emacs backup files) back to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 *.py[co]
+*~
 .ipynb_checkpoints
 .mypy_cache/
 __pycache__


### PR DESCRIPTION
I had put *~ in the .gitignore file early on, and requested that *~ be kept in in multiple PR's that had removed it, but apparently the removal slipped through.  I use emacs, set to keep MULTIPLE numbered backup files per file (and find it often saves my posterior), but seeing all those files in git status is a lot of visual noise.

A plea: When you think something needs to be removed, *PLEASE* contact the person who added it in the first place and discuss why you think it should go away!