### PR TITLE
indexer/pipeline.py: fix typo (print things -> print thing)

### DIFF
--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -220,7 +220,7 @@ class Pipeline(QApp):
             if things:
                 print(what)
                 for thing in things:
-                    print("   ", things)
+                    print("   ", thing)
             else:
                 print(f"no {what}")
 


### PR DESCRIPTION
trivial fix: was printing whole list multiple times, instead of one item at a time