### PR TITLE
ES publication date bugfix

### DIFF
--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -79,11 +79,14 @@ class TestElasticsearchConnection:
     def test_index_document_with_none_date(self, elasticsearch_client: Any) -> None:
         index_names = list(elasticsearch_client.indices.get_alias().keys())
         index_name = index_names[0]
-        test_data_with_none_date = test_data.copy()
+        test_data_with_none_date = dict(test_data).copy()
         test_data_with_none_date["publication_date"] = None
-        response = elasticsearch_client.index(index=index_name, document=test_data_with_none_date)
+        response = elasticsearch_client.index(
+            index=index_name, document=test_data_with_none_date
+        )
         assert response["result"] == "created"
         assert "_id" in response
+
 
 @pytest.fixture(scope="class")
 def elasticsearch_connector() -> ElasticsearchConnector:

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -154,8 +154,8 @@ class ElasticsearchImporter(StoryWorker):
         if publication_date_str:
             try:
                 year = datetime.strptime(publication_date_str, "%Y-%m-%d").year
-            except ValueError:
-                year = -1
+            except ValueError as e:
+                logger.error(f"Error parsing date: {str(e)}")
 
         index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
         if year and year >= 2021:


### PR DESCRIPTION
Handle cases where the `Parser` returns publication date of `None`
Trying to index the wrong data type into a field throws an exception by default, and rejects the whole document. The ignore_malformed parameter, if set to true, allows the exception to be ignored. The malformed field is not indexed, but other fields in the document are processed normally.