### PR TITLE
More deploy updates

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -89,6 +89,15 @@ dirty() {
     IS_DIRTY=1
 }
 
+# news-search-api sources in separate repo, by popular opinion,
+# but deploying from our docker-compose file for network access.
+# but not yet/currently building it from there.
+echo looking for news-search-api docker image:
+if ! docker images | grep colsearch; then
+    echo news-search-api docker image not found. 1>&2
+    echo 'run "docker compose build" in news-search-api repo' 1>&2
+fi
+
 if ! git diff --quiet; then
     dirty 'local changes not checked in' 1>&2
 fi

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -237,6 +237,24 @@ services:
       <<: *worker-environment-vars
       RUN: rabbitmq-stats
 
+  ################ news search api (built elsewhere)
+
+  # NOTE! Not building Docker image here (yet)
+  # until version/revision control issues worked out.
+
+  news-search-api:
+    image: colsearch
+    ports:
+      - 8000:8000
+
+  news-search-ui:
+    command: streamlit run ui.py
+    environment:
+      APIURL: http://news-search-api:8000/v1
+    image: colsearch
+    ports:
+      - 8001:8501
+
 volumes:
 {% for i in range(1,(elastic_num_nodes | int)+1) %}
   elasticsearch_data_{{"%02d" % i}}:


### PR DESCRIPTION
* run 20 batches under production or staging, 10 under development
* limit articles fetched under development with --num-batches 50000
* hardwire rabbitmq in-container hostname for queue persistence
* pass ELASTICSEARCH_HOSTS & ELASTICSEARCH_INDEX_NAME_PREFIX to importer