### PR TITLE
Es indexing update

### DIFF
--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -22,7 +22,7 @@ def set_env() -> None:
     os.environ["ELASTICSEARCH_HOSTS"] = ",".join(
         ["http://localhost:9200", "http://localhost:9201", "http://localhost:9202"]
     )
-    os.environ["ELASTICSEARCH_INDEX_NAME"] = "test_mediacloud_search_text_older"
+    # os.environ["ELASTICSEARCH_INDEX_NAME"] = "test_mediacloud_search_text_older"
     os.environ["ELASTICSEARCH_INDEX_NAME_PREFIX"] = "test_mediacloud_search_text"
 
 
@@ -38,14 +38,14 @@ def elasticsearch_client() -> Any:
     assert hosts is not None, "ELASTICSEARCH_HOSTS is not set"
     client = create_elasticsearch_client(hosts=hosts)
     assert client.ping(), "Failed to connect to Elasticsearch"
-    index_name = os.environ.get("ELASTICSEARCH_INDEX_NAME")
-    assert index_name is not None, "ELASTICSEARCH_INDEX_NAME is not set"
+    index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
+    assert index_name_prefix is not None, "ELASTICSEARCH_INDEX_NAME_PREFIX is not set"
 
-    recreate_indices(client, index_name)
+    recreate_indices(client, index_name_prefix)
 
     yield client
 
-    recreate_indices(client, index_name)
+    recreate_indices(client, index_name_prefix)
 
 
 test_data: Mapping[str, Optional[Union[str, bool]]] = {
@@ -91,11 +91,7 @@ class TestElasticsearchConnection:
 @pytest.fixture(scope="class")
 def elasticsearch_connector() -> ElasticsearchConnector:
     elasticsearch_hosts = cast(str, os.environ.get("ELASTICSEARCH_HOSTS"))
-    index_name = os.environ.get("ELASTICSEARCH_INDEX_NAME")
-    assert index_name is not None, "ELASTICSEARCH_INDEX_NAME is not set"
-    connector = ElasticsearchConnector(
-        elasticsearch_hosts, index_name, es_mappings, es_settings
-    )
+    connector = ElasticsearchConnector(elasticsearch_hosts, es_mappings, es_settings)
     return connector
 
 
@@ -128,6 +124,6 @@ class TestElasticsearchImporter:
         index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
         assert index_name_prefix is not None
         assert importer.index_routing("2023-06-27") == f"{index_name_prefix}_2023"
-        assert importer.index_routing(None) == f"{index_name_prefix}_older"
+        assert importer.index_routing(None) == f"{index_name_prefix}_other"
         assert importer.index_routing("2022-06-27") == f"{index_name_prefix}_2022"
         assert importer.index_routing("2020-06-27") == f"{index_name_prefix}_older"

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -40,11 +40,11 @@ def elasticsearch_client() -> Any:
     index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
     assert index_name_prefix is not None, "ELASTICSEARCH_INDEX_NAME_PREFIX is not set"
 
-    recreate_indices(client, index_name_prefix)
+    recreate_indices(client, f"{index_name_prefix}_older")
 
     yield client
 
-    recreate_indices(client, index_name_prefix)
+    recreate_indices(client, f"{index_name_prefix}_older")
 
 
 test_data: Mapping[str, Optional[Union[str, bool]]] = {

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -22,7 +22,6 @@ def set_env() -> None:
     os.environ["ELASTICSEARCH_HOSTS"] = ",".join(
         ["http://localhost:9200", "http://localhost:9201", "http://localhost:9202"]
     )
-    # os.environ["ELASTICSEARCH_INDEX_NAME"] = "test_mediacloud_search_text_older"
     os.environ["ELASTICSEARCH_INDEX_NAME_PREFIX"] = "test_mediacloud_search_text"
 
 

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -88,8 +88,12 @@ class ElasticsearchConnector:
                     mappings=self.mappings,
                     settings=self.settings,
                 )
+                logger.info(f"Index '{index_name}' created successfully.")
             else:
                 self.client.indices.create(index=index_name)
+                logger.info(f"Index '{index_name}' created successfully.")
+        else:
+            logger.warning(f"Index '{index_name}' already exists. Skipping creation.")
 
     def index(
         self, id: str, index_name: str, document: Mapping[str, Any]
@@ -152,11 +156,12 @@ class ElasticsearchImporter(StoryWorker):
                 current_year = datetime.now().year
 
                 if year > current_year:
-                    raise QuarantineException(
-                        "Publication year cannot be in the future."
+                    year = -1
+                    logger.warning(
+                        f"Publication date greater than current year: {current_year}"
                     )
             except ValueError as e:
-                logger.error(f"Error parsing date: {str(e)}")
+                logger.warning(f"Error parsing date: {str(e)}")
 
         index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
         if 2021 <= year <= current_year:

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -15,7 +15,7 @@ from elasticsearch import Elasticsearch
 from pika.adapters.blocking_connection import BlockingChannel
 
 from indexer.story import BaseStory
-from indexer.worker import QuarantineException, StoryWorker, run
+from indexer.worker import StoryWorker, run
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR introduces;
1 .Set index namesmediacloud_search_text_older for pre 2020 dates and mediacloud_search_text_other for NULL dates and future publication dates
2. Remove ELASTICSEARCH_INDEX_NAME, not required param at initialization