### PR TITLE
Report Elastic Search stats to graphite-grafana

### DIFF
--- a/bin/run-elastic-stats.sh
+++ b/bin/run-elastic-stats.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. bin/func.sh
+
+run_python indexer.scripts.elastic-stats "$@"

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -88,6 +88,7 @@ x-worker-service-settings: &worker-service-settings
 
   environment: &worker-environment-vars
     <<: *base-environment-vars
+    ELASTICSEARCH_HOSTS: "http://elasticsearch1:9200/{% for i in range(2,(elastic_num_nodes | int)+1) %},http://elasticsearch{{i}}:{{9200 + i - 1}}/{% endfor %}"
     LOG_LEVEL: "info"
     RABBITMQ_URL: {{rabbitmq_url}}
     STATSD_REALM: {{statsd_realm}}
@@ -236,6 +237,12 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: rabbitmq-stats
+
+  elastic-stats:
+    <<: *worker-service-settings
+    environment:
+      <<: *worker-environment-vars
+      RUN: elastic-stats
 
   ################ news search api (built elsewhere)
 

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -88,7 +88,7 @@ x-worker-service-settings: &worker-service-settings
 
   environment: &worker-environment-vars
     <<: *base-environment-vars
-    ELASTICSEARCH_HOSTS: "http://elasticsearch1:9200/{% for i in range(2,(elastic_num_nodes | int)+1) %},http://elasticsearch{{i}}:{{9200 + i - 1}}/{% endfor %}"
+    ELASTICSEARCH_HOSTS: {{elasticsearch_hosts}}
     LOG_LEVEL: "info"
     RABBITMQ_URL: {{rabbitmq_url}}
     STATSD_REALM: {{statsd_realm}}
@@ -224,7 +224,6 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: importer
-      ELASTICSEARCH_HOSTS: {{elasticsearch_hosts}}
       ELASTICSEARCH_INDEX_NAME_PREFIX: mediacloud_search_text
       ELASTICSEARCH_INDEX_NAME: is_this_still_needed
       ELASTICSEARCH_REPLICAS: {{elasticsearch_replicas}}

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -9,7 +9,7 @@ import sys
 import time
 import urllib.parse
 from types import TracebackType
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Protocol, Tuple
 
 # PyPI
 import statsd  # depends on stubs/statsd.pyi
@@ -297,6 +297,20 @@ class _TimingContext:
         logger.debug("%s: %g ms", self.name, ms)
         self.app.timing(self.name, ms)
         self.t0 = -1.0
+
+
+class ArgsProtocol(Protocol):
+    """
+    class for "self" in App mixins that declare options
+    """
+
+    args: Optional[argparse.Namespace]
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        ...
+
+    def process_args(self) -> None:
+        ...
 
 
 if __name__ == "__main__":

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -31,7 +31,18 @@ class AppException(RuntimeError):
     """
 
 
-class App:
+class ArgsProtocol(Protocol):
+    """
+    class for "self" in App mixins that declare & access command line args
+    """
+
+    args: Optional[argparse.Namespace]
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        ...
+
+
+class App(ArgsProtocol):
     """
     Base class for command line applications (ie; Worker)
     """
@@ -299,18 +310,30 @@ class _TimingContext:
         self.t0 = -1.0
 
 
-class ArgsProtocol(Protocol):
+class IntervalMixin(ArgsProtocol):
     """
-    class for "self" in App mixins that declare options
+    Mixin for Apps that report stats at a fixed interval
     """
-
-    args: Optional[argparse.Namespace]
 
     def define_options(self, ap: argparse.ArgumentParser) -> None:
-        ...
+        super().define_options(ap)
 
-    def process_args(self) -> None:
-        ...
+        default = 60
+        ap.add_argument(
+            "--interval",
+            type=int,
+            help=f"reporting interval in seconds (default {default})",
+            default=default,
+        )
+
+    def interval_sleep(self) -> None:
+        assert self.args
+
+        # sleep until top of next interval
+        seconds = self.args.interval
+        sleep_sec = seconds - time.time() % seconds
+        logger.debug("sleep %.6g", sleep_sec)
+        time.sleep(sleep_sec)
 
 
 if __name__ == "__main__":

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -16,7 +16,7 @@ from elasticsearch import Elasticsearch
 
 from indexer.app import ArgsProtocol
 
-logger = getLogger("elastic-stats")
+logger = getLogger(__name__)
 
 
 class ElasticMixin:

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -1,5 +1,5 @@
 """
-Elastic Search App utilities
+Elastic Search App Mixin
 """
 
 # from indexer.workers.importer
@@ -30,7 +30,7 @@ class ElasticMixin:
         ap.add_argument(
             "--elasticsearch-hosts",
             dest="elasticsearch_hosts",
-            default=os.environ.get("ELASTICSEARCH_HOSTS"),
+            default=os.environ.get("ELASTICSEARCH_HOSTS") or "",
             help="comma separated list of ES server URLs",
         )
 
@@ -40,4 +40,6 @@ class ElasticMixin:
         if not hosts:
             logger.fatal("need --elasticsearch-hosts or ELASTICSEARCH_HOSTS")
             sys.exit(1)
+
+        # Connects immediately, performs failover and retries
         return Elasticsearch(hosts.split(","))

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -1,0 +1,41 @@
+"""
+Elastic Search App utilities
+"""
+
+# from indexer.workers.importer
+
+import argparse
+import os
+import sys
+from logging import getLogger
+from typing import Any, List, Optional
+from urllib.parse import urlparse
+
+from elastic_transport import NodeConfig, ObjectApiResponse
+from elasticsearch import Elasticsearch
+
+logger = getLogger("elastic-stats")
+
+# would prefer to have an ElasticMixin for Apps, but would need a
+# "protocol" to inherit from, so a bunch of functions to call
+# from App methods.
+
+
+def add_elasticsearch_hosts(ap: argparse.ArgumentParser) -> None:
+    ap.add_argument(
+        "--elasticsearch-hosts",
+        dest="elasticsearch_hosts",
+        default=os.environ.get("ELASTICSEARCH_HOSTS"),
+        help="override ELASTICSEARCH_HOSTS",
+    )
+
+
+def check_elasticsearch_hosts(hosts: Optional[str]) -> str:
+    if not hosts:
+        logger.fatal("need --elasticsearch-hosts or ELASTICSEARCH_HOSTS")
+        sys.exit(1)
+    return hosts
+
+
+def create_elasticsearch_client(hosts_str: str) -> Elasticsearch:
+    return Elasticsearch(hosts_str.split(","))  # type: ignore[arg-type]

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -1,0 +1,56 @@
+"""
+report Elastic Search stats to statsd
+"""
+
+# Phil, from rabbitmq-stats.py
+# with help from importer
+
+import argparse
+import time
+from logging import getLogger
+from typing import Any, Dict
+
+from elastic_transport import ConnectionError, ConnectionTimeout
+
+from indexer.app import App
+from indexer.elastic import (
+    add_elasticsearch_hosts,
+    check_elasticsearch_hosts,
+    create_elasticsearch_client,
+)
+
+logger = getLogger("elastic-stats")
+
+
+class ElasticStats(App):
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+
+        add_elasticsearch_hosts(ap)
+
+        ap.add_argument(
+            "--interval", type=float, help="reporting interval in seconds", default=60.0
+        )
+
+    def main_loop(self) -> None:
+        assert self.args
+        seconds = self.args.interval
+
+        hosts = self.args.elasticsearch_hosts
+        es = create_elasticsearch_client(check_elasticsearch_hosts(hosts))
+
+        while True:
+            try:
+                print(es.cat.indices(bytes="mb", pri=True))
+            except (ConnectionError, ConnectionTimeout) as e:
+                logger.debug("indices: %r", e)
+
+            # sleep until top of next period:
+            sleep_sec = seconds - time.time() % seconds
+            logger.debug("sleep %.6g", sleep_sec)
+            time.sleep(sleep_sec)
+
+
+if __name__ == "__main__":
+    app = ElasticStats("elastic-stats", "Send Elastic Search stats to statsd")
+    app.main()

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -7,8 +7,9 @@ report Elastic Search stats to statsd
 
 import argparse
 import time
+from collections import Counter
 from logging import getLogger
-from typing import Any, Dict
+from typing import Any, Dict, List, cast
 
 from elastic_transport import ConnectionError, ConnectionTimeout
 
@@ -18,7 +19,7 @@ from indexer.elastic import ElasticMixin
 logger = getLogger("elastic-stats")
 
 
-class ElasticStats(App, ElasticMixin):
+class ElasticStats(ElasticMixin, App):
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
 
@@ -34,7 +35,32 @@ class ElasticStats(App, ElasticMixin):
 
         while True:
             try:
-                print(es.cat.indices(bytes="mb", pri=True))
+                # limit to columns of interest?
+                indices = cast(
+                    List[Dict[str, str]],
+                    es.cat.indices(bytes="mb", pri=True, format="json"),
+                )
+                health: Counter[str] = Counter()
+                for index in indices:
+                    name = index["index"]
+                    logger.debug("index: %s", name)
+
+                    def by_index(input: str, out: str) -> None:
+                        val = int(index[input])
+                        logger.debug(" %s %s %d", input, out, val)
+                        self.gauge("indices." + out, val, labels=[("index", name)])
+
+                    by_index("docs.count", "docs")
+                    by_index("docs.deleted", "deleted")
+                    by_index("pri.store.size", "pri-size")
+                    health[index["health"]] += 1
+
+                # report totals for each health state
+                for color in ("green", "red", "yellow"):
+                    count = health[color]
+                    logger.debug("%s %d", color, count)
+                    self.gauge("indices.health", count, labels=[("color", color)])
+
             except (ConnectionError, ConnectionTimeout) as e:
                 logger.debug("indices: %r", e)
 

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -13,20 +13,14 @@ from typing import Any, Dict
 from elastic_transport import ConnectionError, ConnectionTimeout
 
 from indexer.app import App
-from indexer.elastic import (
-    add_elasticsearch_hosts,
-    check_elasticsearch_hosts,
-    create_elasticsearch_client,
-)
+from indexer.elastic import ElasticMixin
 
 logger = getLogger("elastic-stats")
 
 
-class ElasticStats(App):
+class ElasticStats(App, ElasticMixin):
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
-
-        add_elasticsearch_hosts(ap)
 
         ap.add_argument(
             "--interval", type=float, help="reporting interval in seconds", default=60.0
@@ -36,8 +30,7 @@ class ElasticStats(App):
         assert self.args
         seconds = self.args.interval
 
-        hosts = self.args.elasticsearch_hosts
-        es = create_elasticsearch_client(check_elasticsearch_hosts(hosts))
+        es = self.elasticsearch_client()
 
         while True:
             try:

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -16,11 +16,6 @@ from elastic_transport import ConnectionError, ConnectionTimeout
 from indexer.app import App, IntervalMixin
 from indexer.elastic import ElasticMixin
 
-# Reporting unit for storage.
-# Changing this will cause a discontinuity in graphs!!!
-# But here for clarity, and for reference in comments!
-BYTES = "mb"
-
 logger = getLogger("elastic-stats")
 
 
@@ -33,7 +28,7 @@ class ElasticStats(ElasticMixin, IntervalMixin, App):
                 # limit to columns of interest?
                 indices = cast(
                     List[Dict[str, str]],
-                    es.cat.indices(bytes=BYTES, pri=True, format="json"),
+                    es.cat.indices(pri=True, format="json"),
                 )
                 health: Counter[str] = Counter()
                 for index in indices:
@@ -49,7 +44,7 @@ class ElasticStats(ElasticMixin, IntervalMixin, App):
 
                     by_index("docs.count", "docs")
                     by_index("docs.deleted", "deleted")
-                    by_index("pri.store.size", "pri-size")  # in BYTES
+                    by_index("pri.store.size", "pri-size")
                     health[index["health"]] += 1
 
                 # report totals for each health state

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -28,7 +28,7 @@ class ElasticStats(ElasticMixin, IntervalMixin, App):
                 # limit to columns of interest?
                 indices = cast(
                     List[Dict[str, str]],
-                    es.cat.indices(pri=True, format="json"),
+                    es.cat.indices(bytes="b", pri=True, format="json"),
                 )
                 health: Counter[str] = Counter()
                 for index in indices:

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -21,6 +21,10 @@ logger = getLogger("elastic-stats")
 
 class ElasticStats(ElasticMixin, IntervalMixin, App):
     def main_loop(self) -> None:
+        # maybe:
+        # getLogger("elastic_transport.transport").setLevel(logging.WARNING)
+        # to avoid log message for each GET?
+
         es = self.elasticsearch_client()
 
         while True:

--- a/indexer/scripts/rabbitmq-stats.py
+++ b/indexer/scripts/rabbitmq-stats.py
@@ -16,23 +16,18 @@ from typing import Any, Dict
 # PyPI
 from requests.exceptions import ConnectionError
 
+from indexer.app import IntervalMixin
 from indexer.worker import QApp
 
 logger = getLogger("rabbitmq-stats")
 
 
-class QStats(QApp):
+class QStats(IntervalMixin, QApp):
     """
     monitor RabbitMQ via AdminAPI
     """
 
     AUTO_CONNECT = False  # never connects (uses AdminAPI)!
-
-    def define_options(self, ap: argparse.ArgumentParser) -> None:
-        super().define_options(ap)
-        ap.add_argument(
-            "--interval", type=float, help="reporting interval in seconds", default=60.0
-        )
 
     def g(
         self,
@@ -58,57 +53,47 @@ class QStats(QApp):
         self.gauge(output, value, [(label, label_value)])
 
     def main_loop(self) -> None:
-        assert self.args
-        seconds = self.args.interval
-
         api = self.admin_api()
 
-        # on startup, wait until a request succeeds
         while True:
             try:
-                api.overview()
-                break
+                # PLB: FEH! # primary URL I want isn't included in API!
+                # Looks like the core of AdminAPI doesn't do pagination either!!!
+
+                queues = api._api_get("/api/queues")
+                # returns List[Dict[str,Any]]
+
+                for q in queues:
+                    name = q.get("name")
+                    self.g(q, "memory", "queues", "mem", "name", name)
+                    self.g(q, "messages_ready", "queues", "ready", "name", name)
+                    self.g(
+                        q, "messages_unacknowledged", "queues", "unacked", "name", name
+                    )
+
+                    ms = q.get("message_stats", None)
+                    self.g(ms, "ack", "queues", "ack", "name", name)
+                    self.g(ms, "deliver", "queues", "deliver", "name", name)
+                    self.g(ms, "publish", "queues", "publish", "name", name)
+                    self.g(ms, "redeliver", "queues", "redeliver", "name", name)
+                    self.g(ms, "consumers", "queues", "consumers", "name", name)
+
+                nodes = api.list_nodes()
+                for node in nodes:  # List
+                    # leading part is cluster name, split and give second part??
+                    name = node.get("name").replace("@", "-")
+                    self.g(node, "fd_used", "nodes", "fds", "name", name)
+                    self.g(node, "mem_used", "nodes", "memory", "name", name)
+                    self.g(node, "sockets_used", "nodes", "sockets", "name", name)
+
+                # exchange: unroutable?? (need to skip SEMAPHORE!)
+                # exchanges = api.list_exchanges()
+                # List w/ {"name": "foo", "message_stats": { ... }}
             except (ConnectionError, gaierror) as e:
-                logger.info("startup: %r", e)
-                time.sleep(30)
-
-        logger.info("ready")
-        while True:
-            # PLB: FEH!  All the bother to make AdminMixin, and the
-            # primary URL I want isn't included!  Looks like the core of
-            # AdminAPI doesn't do pagination either!!!
-            queues = api._api_get("/api/queues")
-
-            # returns List[Dict[str,Any]]
-            for q in queues:
-                name = q.get("name")
-                self.g(q, "memory", "queues", "mem", "name", name)
-                self.g(q, "messages_ready", "queues", "ready", "name", name)
-                self.g(q, "messages_unacknowledged", "queues", "unacked", "name", name)
-
-                ms = q.get("message_stats", None)
-                self.g(ms, "ack", "queues", "ack", "name", name)
-                self.g(ms, "deliver", "queues", "deliver", "name", name)
-                self.g(ms, "publish", "queues", "publish", "name", name)
-                self.g(ms, "redeliver", "queues", "redeliver", "name", name)
-                self.g(ms, "consumers", "queues", "consumers", "name", name)
-
-            nodes = api.list_nodes()
-            for node in nodes:  # List
-                # leading part is cluster name, split and give second part??
-                name = node.get("name").replace("@", "-")
-                self.g(node, "fd_used", "nodes", "fds", "name", name)
-                self.g(node, "mem_used", "nodes", "memory", "name", name)
-                self.g(node, "sockets_used", "nodes", "sockets", "name", name)
-
-            # exchange: unroutable?? (need to skip SEMAPHORE!)
-            # exchanges = api.list_exchanges()
-            # List w/ {"name": "foo", "message_stats": { ... }}
+                logger.debug("caught %r", e)
 
             # sleep until top of next period:
-            sleep_sec = seconds - time.time() % seconds
-            logger.debug("sleep %.6g", sleep_sec)
-            time.sleep(sleep_sec)
+            self.interval_sleep()
 
 
 if __name__ == "__main__":

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -83,7 +83,7 @@ class ElasticsearchConnector:
         return response
 
 
-class ElasticsearchImporter(StoryWorker, ElasticMixin):
+class ElasticsearchImporter(ElasticMixin, StoryWorker):
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
         ap.add_argument(

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -54,7 +54,6 @@ class ElasticsearchConnector:
         mappings: Mapping[str, Any],
         settings: Mapping[str, Any],
     ) -> None:
-        assert isinstance(hosts, str)
         self.client = client
         self.mappings = mappings
         self.settings = settings


### PR DESCRIPTION
*Low priority*, for https://github.com/mediacloud/story-indexer/issues/103

* Creates indexer/scripts/elastic-stats.py. bin/run-elastic.stats and an elastic-stats container
* Creates indexer.app.ArgsProtocol for App mixins
* Creates indexer.app.IntervalMixin with `--interval` option for use by {elastic,rabbitmq}-stats.py
* Creates indexer.elastic.ElasticMixin with `--elasticsearch-hosts` with code from workers/importer.py: use in importer and elastic-stats

This is my first attempt at writing mixin classes in a project checked by mypy, so I could well be doing it wrong!

I abstracted code from importer.py and rabbitmq-stats.py to create two mixins for common command-line arguments, and their implementation.

Because the `ElasticMixin.elasticsearch_client` method returns an `Elasticsearch` client object I modified the indexer `ElasticsearchConnector` to take a client object rather than the fully general possibilities that the `Elasticsearch` constructor allows, and it seems like it does the right thing a list of URLs, but I'm wondering if I'm missing a reason for the old way (converting the URLs to `NodeConfig` objects)??

elastic-stats reports `docs` (document count), `deleted` (deleted/duplicate documents) and `pri-size` (size of primary index in MB) for each index, as well as counts of indices in each color/state: green/yellow/red, which could be useful for alerting.

I chose to use the short name "elastic" in filenames rather than the longer "elasticsearch", but I could be convinced otherwise!!