### PR TITLE
Changes to indexer.worker to perform all Pika I/O on a thread

### DIFF
--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -174,6 +174,9 @@ class QApp(App):
         if self.args.from_quarantine:
             self.input_queue_name = quarantine_queue_name(self.process_name)
 
+        if self.AUTO_CONNECT:
+            self.qconnect()
+
     def _test_configured(self) -> bool:
         """
         NOTE! Called before Pika thread launched,
@@ -234,7 +237,7 @@ class QApp(App):
 
     def _run_pika_thread(self) -> None:
         """
-        called after channels are open
+        called after channels are open; launches pika I/O thread
         """
         self._pika_thread = threading.Thread(
             target=self._pika_thread_body, name="Pika-thread"
@@ -325,8 +328,6 @@ class Worker(QApp):
         basic main_loop for a consumer.
         override for a producer!
         """
-
-        self.qconnect()
 
         assert self._conn
         chan = self._conn.channel()

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -32,6 +32,8 @@ class Parser(StoryWorker):
         if not html:
             raise QuarantineException("no html")
 
+        logger.info("parsing %s: %d characters", link, len(html))
+
         # metadata dict
         # may raise mcmetadata.exceptions.BadContentError
         #   What to do?
@@ -50,6 +52,8 @@ class Parser(StoryWorker):
             mdd["publication_date"] = mdd["publication_date"].strftime("%Y-%m-%d")
         else:
             mdd["publication_date"] = "None"
+
+        logger.info("parsed %s with %s date %s", link, extraction_label, mdd["publication_date"])
 
         with story.content_metadata() as cmd:
             # XXX assumes identical item names!!

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -12,7 +12,7 @@ from pika.adapters.blocking_connection import BlockingChannel
 from indexer.story import BaseStory
 from indexer.worker import QuarantineException, StoryWorker, run
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("parser")
 
 
 class Parser(StoryWorker):
@@ -53,7 +53,9 @@ class Parser(StoryWorker):
         else:
             mdd["publication_date"] = "None"
 
-        logger.info("parsed %s with %s date %s", link, extraction_label, mdd["publication_date"])
+        logger.info(
+            "parsed %s with %s date %s", link, extraction_label, mdd["publication_date"]
+        )
 
         with story.content_metadata() as cmd:
             # XXX assumes identical item names!!


### PR DESCRIPTION
The inspiration was that the parser was seeing Pika connection timeouts due to long-running parse operations.

Removed some stuff from indexer.worker we weren't using (batches), to simplify the work.

I did the cleanest job I could without changing the Worker API (needing to change parser and importer).