### PR TITLE
Fixes for Pika thread

### DIFF
--- a/indexer/app.py
+++ b/indexer/app.py
@@ -251,6 +251,11 @@ class App:
         """
         return _TimingContext(self, name)
 
+    def cleanup(self) -> None:
+        """
+        when overridden, call super().cleanup()
+        """
+
     ################ main program
 
     def main(self) -> None:
@@ -261,7 +266,10 @@ class App:
         self._stats_init()
 
         with self.timer("main_loop"):  # also serves as restart count
-            self.main_loop()
+            try:
+                self.main_loop()
+            finally:
+                self.cleanup()
 
     def main_loop(self) -> None:
         """

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -298,11 +298,11 @@ class QApp(App):
         """
         if self._pika_thread:
             logger.error("_start_pika_thread called again")
+            return
 
         self._pika_thread = threading.Thread(
-            target=self._pika_thread_body, name="Pika-thread"
+            target=self._pika_thread_body, name="Pika-thread", daemon=True
         )
-        self._pika_thread.daemon = True  # remove need to join before exit???
         self._pika_thread.start()
 
     def _subscribe(self) -> None:
@@ -324,22 +324,46 @@ class QApp(App):
         """
         ptlogger.info("Pika thread starting")
 
+        # hook for Workers to make consume calls,
+        # (and/or any blocking calls, like exchange/queue creation)
         self._subscribe()
 
         try:
+            # Timeout value means _running can be set to False and main thread
+            # may have to wait for timeout before this thread wakes up and exits.
             while self._running and self.connection and self.connection.is_open:
                 # process_data_events is called by conn.sleep,
                 # but may return sooner:
                 self.connection.process_data_events(10)
         finally:
+            # Trying clean close, in case process_data_events returns
+            # with unprocessed events (especially send callbacks).
+            if self.connection and self.connection.is_open:
+                self.connection.close()
+            self.connection = None
             self._running = False  # tell _process_messages
 
-        # here if _running was set False, or connection closed (w/o Exception)
-        ptlogger.info("Pika thread exiting")
+            # here if _running was set False, connection closed, exception thrown
+            ptlogger.info("Pika thread exiting")
 
     def _call_in_pika_thread(self, cb: Callable[[], None]) -> None:
         assert self.connection
         self.connection.add_callback_threadsafe(cb)
+
+    def cleanup(self) -> None:
+        super().cleanup()
+        # saw error "Fatal Python error: _enter_buffered_busy: could
+        #   not acquire lock for <_io.BufferedWriter name='<stderr>'> at
+        #   interpreter shutdown, possibly due to daemon threads"
+        # so asking Pika thread to exit, and waiting for it.
+        if self._pika_thread and self._pika_thread.is_alive():
+            # may take thread
+            self._running = False
+            # Log message in case Pika thread hangs.
+            logger.info("Waiting for Pika thread")
+            # could issue join with timeout.
+            self._pika_thread.join()
+            self._pika_thread = None
 
     def send_message(
         self,
@@ -354,6 +378,12 @@ class QApp(App):
         It would be cleaner to pass InputMessage object with send methods to Workers,
         so bare channel is never exposed to worker code.  Maybe later.
         """
+        if self._pika_thread is None:
+            # here from a QApp
+            # transactions will NOT be enabled
+            # (unless _subscribe is overridden)
+            self._start_pika_thread()
+
         if exchange is None:
             exchange = self.output_exchange_name
 


### PR DESCRIPTION
Fixes some issues:
* start Pika thread if a QApp (non-consumer) calls send_message
* pass daemon argument to Thread
* try clean shutdown of Pika thread to resolve errors at exit