### PR TITLE
Proposed quick fix for RabbitMQ startup race

### DIFF
--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -208,8 +208,7 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: configure-pipeline
-      ARGS: "configure"
-      # exits successfully, won't be restarted
+      ARGS: "configure_and_loop"
 
   fetcher-worker:
     <<: *worker-service-settings

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -248,6 +248,18 @@ class Pipeline(QApp):
         self._configure(True)
 
     @command
+    def configure_and_loop(self) -> None:
+        """loop configuring queues etc and sleeping to handle RabbitMQ restart"""
+        # this exists to handle the race if this starts
+        # before RabbitMQ restarts.
+        # NOTE: not handling exceptions, let Docker restart.
+        while True:
+            if not self._test_configured():
+                self._configure(True)
+            assert self.connection
+            self.connection.sleep(5 * 60)
+
+    @command
     def delete(self) -> None:
         """delete queues etc."""
         self._configure(False)


### PR DESCRIPTION
see https://github.com/mediacloud/story-indexer/is)sues/117

(if rabbitmq container restarts after index.pipeline configure, workers hang)