### PR TITLE
Update ES mapping to index story's first captured time

### DIFF
--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -19,25 +19,6 @@ from indexer.app import ArgsProtocol
 logger = getLogger(__name__)
 
 
-def create_elasticsearch_client(
-    hosts: Union[str, List[Union[str, Mapping[str, Union[str, int]], NodeConfig]]],
-) -> Elasticsearch:
-    if isinstance(hosts, str):
-        host_urls = hosts.split(",")
-
-    host_configs: Any = []
-    for host_url in host_urls:
-        parsed_url = urlparse(host_url)
-        host = parsed_url.hostname
-        scheme = parsed_url.scheme
-        port = parsed_url.port
-        if host and scheme and port:
-            node_config = NodeConfig(scheme=scheme, host=host, port=port)
-            host_configs.append(node_config)
-
-    return Elasticsearch(host_configs)
-
-
 class ElasticMixin:
     """
     mixin class for Apps that use Elastic Search API
@@ -60,6 +41,4 @@ class ElasticMixin:
             logger.fatal("need --elasticsearch-hosts or ELASTICSEARCH_HOSTS")
             sys.exit(1)
 
-        # Connects immediately, performs failover and retries
-        es_client = create_elasticsearch_client(hosts)
-        return es_client
+        return Elasticsearch(hosts.split(","))

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -8,7 +8,7 @@ import argparse
 import os
 import sys
 from logging import getLogger
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, List, Optional
 from urllib.parse import urlparse
 
 from elastic_transport import NodeConfig, ObjectApiResponse
@@ -41,4 +41,5 @@ class ElasticMixin:
             logger.fatal("need --elasticsearch-hosts or ELASTICSEARCH_HOSTS")
             sys.exit(1)
 
+        # Connects immediately, performs failover and retries
         return Elasticsearch(hosts.split(","))

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -10,7 +10,7 @@ import pytest
 from elastic_transport import NodeConfig
 from elasticsearch import Elasticsearch
 
-from indexer.elastic import create_elasticsearch_client
+# from indexer.elastic import create_elasticsearch_client
 from indexer.workers.importer import (
     ElasticsearchConnector,
     ElasticsearchImporter,
@@ -35,9 +35,9 @@ def recreate_indices(client: Elasticsearch, index_name: str) -> None:
 
 @pytest.fixture(scope="class")
 def elasticsearch_client() -> Any:
-    hosts = os.environ.get("ELASTICSEARCH_HOSTS")
+    hosts: Any = os.environ.get("ELASTICSEARCH_HOSTS")
     assert hosts is not None, "ELASTICSEARCH_HOSTS is not set"
-    client = create_elasticsearch_client(hosts=hosts)
+    client = Elasticsearch(hosts.split(","))
     assert client.ping(), "Failed to connect to Elasticsearch"
     index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
     assert index_name_prefix is not None, "ELASTICSEARCH_INDEX_NAME_PREFIX is not set"

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -138,9 +138,8 @@ class TestElasticsearchImporter:
         if response is not None:
             assert response.get("result") == "created"
 
-        with pytest.raises(QuarantineException) as exc_info:
-            importer.import_story(test_import_data)
-        assert "ConflictError" in str(exc_info.value)
+        second_response = importer.import_story(test_import_data)
+        assert second_response is None
 
     def test_index_routing(
         self,

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -147,8 +147,6 @@ class TestElasticsearchImporter:
         elasticsearch_connector: ElasticsearchConnector,
     ) -> None:
         importer.connector = elasticsearch_connector
-        importer.index_name_prefix = os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX")
-        assert importer.index_name_prefix is not None
         assert (
             importer.index_routing("2023-06-27") == f"{importer.index_name_prefix}_2023"
         )

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -179,7 +179,7 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
                 self.incr("stories", labels=[("status", "dups")])
 
             except RequestError as e:
-                self.incr("imported-stories", labels=[("status", "reqerr")])
+                self.incr("stories", labels=[("status", "reqerr")])
                 raise QuarantineException(getattr(e, "message", repr(e)))
 
             if response and response.get("result") == "created":

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -175,9 +175,9 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
             target_index = self.index_routing(publication_date)
             try:
                 response = self.connector.index(url_hash, target_index, data)
-            except ConflictError as e:
+            except ConflictError:
                 self.incr("stories", labels=[("status", "dups")])
-                raise QuarantineException(getattr(e, "message", repr(e)))
+
             except RequestError as e:
                 self.incr("imported-stories", labels=[("status", "reqerr")])
                 raise QuarantineException(getattr(e, "message", repr(e)))

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -86,13 +86,13 @@ class ElasticsearchConnector:
 class ElasticsearchImporter(ElasticMixin, StoryWorker):
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
-        # ap.add_argument(
-        #     "--index-name-prefix",
-        #     dest="index_name_prefix",
-        #     type=str,
-        #     default=os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX"),
-        #     help="Elasticsearch index name prefix",
-        # )
+        ap.add_argument(
+            "--index-name-prefix",
+            dest="index_name_prefix",
+            type=str,
+            default=os.environ.get("ELASTICSEARCH_INDEX_NAME_PREFIX"),
+            help="Elasticsearch index name prefix",
+        )
 
     def process_args(self) -> None:
         super().process_args()

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -126,9 +126,7 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
                     year = -1
             except ValueError as e:
                 logger.warning("Error parsing date: '%s" % str(e))
-        index_name_prefix = self.index_name_prefix or os.environ.get(
-            "ELASTICSEARCH_INDEX_NAME_PREFIX"
-        )
+        index_name_prefix = self.index_name_prefix
         if year >= 2021:
             routing_index = f"{index_name_prefix}_{year}"
         elif 2008 <= year <= 2020:


### PR DESCRIPTION
This PR introduces 
1. Adding a story's `indexed_date` to the ES mapping.
2. Using ES's `index API` creates/updates a document - to ensure duplicates are not indexed, we replace the indexing functionality to use `create API`
3. On indexing, we may get `BadRequest` errors from parsing documents during indexing, this stories are Quarantined to be monitored via `400-*` status counter. Duplicate stories also monitored via incremental counter

Fixes #130 
Fixes #141
Fixes #90 
