### PR TITLE
Blacklist Redirect Middleware, and Shorter Timeout

### DIFF
--- a/indexer/workers/fetcher/BlacklistRedirectMiddleware.py
+++ b/indexer/workers/fetcher/BlacklistRedirectMiddleware.py
@@ -1,0 +1,50 @@
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from mcmetadata.urls import NON_NEWS_DOMAINS
+from scrapy.downloadermiddlewares.redirect import (
+    BaseRedirectMiddleware,
+    _build_redirect_request,
+)
+from scrapy.exceptions import IgnoreRequest, NotConfigured
+from scrapy.http import HtmlResponse
+from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.response import get_meta_refresh
+from w3lib.url import safe_url_string
+
+
+class BlacklistRedirectMiddleware(BaseRedirectMiddleware):  # type: ignore[no-any-unimported]
+    """
+    Handle redirection of requests based on response status
+    and meta-refresh html tag. Very Minor Edit of scrapy's builtin RedirectMiddleware
+    """
+
+    def process_response(self, request: Any, response: Any, spider: Any) -> Any:
+        if (
+            request.meta.get("dont_redirect", False)
+            or response.status in getattr(spider, "handle_httpstatus_list", [])
+            or response.status in request.meta.get("handle_httpstatus_list", [])
+            or request.meta.get("handle_httpstatus_all", False)
+        ):
+            return response
+
+        allowed_status = (301, 302, 303, 307, 308)
+        if "Location" not in response.headers or response.status not in allowed_status:
+            return response
+
+        location = safe_url_string(response.headers["Location"])
+        if response.headers["Location"].startswith(b"//"):
+            request_scheme = urlparse(request.url).scheme
+            location = request_scheme + "://" + location.lstrip("/")
+
+        redirected_url = urljoin(request.url, location)
+
+        if any(dom in redirected_url for dom in NON_NEWS_DOMAINS):
+            raise IgnoreRequest("Redirect to blacklisted domain")
+
+        if response.status in (301, 307, 308) or request.method == "HEAD":
+            redirected = _build_redirect_request(request, url=redirected_url)
+            return self._redirect(redirected, request, spider, response.status)
+
+        redirected = self._redirect_request_using_get(request, redirected_url)
+        return self._redirect(redirected, request, spider, response.status)

--- a/indexer/workers/fetcher/BlacklistRedirectMiddleware.py
+++ b/indexer/workers/fetcher/BlacklistRedirectMiddleware.py
@@ -1,6 +1,7 @@
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
+import tldextract
 from mcmetadata.urls import NON_NEWS_DOMAINS
 from scrapy.downloadermiddlewares.redirect import (
     BaseRedirectMiddleware,
@@ -39,7 +40,8 @@ class BlacklistRedirectMiddleware(BaseRedirectMiddleware):  # type: ignore[no-an
 
         redirected_url = urljoin(request.url, location)
 
-        if any(dom in redirected_url for dom in NON_NEWS_DOMAINS):
+        tld = tldextract.extract(redirected_url)
+        if f"{tld.domain}.{tld.suffix}" in NON_NEWS_DOMAINS:
             raise IgnoreRequest("Redirect to blacklisted domain")
 
         if response.status in (301, 307, 308) or request.method == "HEAD":

--- a/indexer/workers/fetcher/batch_spider.py
+++ b/indexer/workers/fetcher/batch_spider.py
@@ -25,6 +25,12 @@ class BatchSpider(scrapy.Spider):  # type: ignore[no-any-unimported]
 
     name: str = "BatchSpider"
 
+    # Use the custom blacklist redirect middleware instead of the standard redirect middleware
+    DOWNLOADER_MIDDLEWARES = {
+        "indexer.workers.fetcher.BlacklistRedirectMiddleware": 500,
+        "scrapy.downloadermiddlewares.redirect.RedirectMiddleware": None,
+    }
+
     custom_settings: Dict[str, Any] = {
         "COOKIES_ENABLED": False,
         "AUTOTHROTTLE_ENABLED": True,
@@ -34,6 +40,8 @@ class BatchSpider(scrapy.Spider):  # type: ignore[no-any-unimported]
         # donut bother with retrying on 500s
         "RETRY_HTTP_CODES": [502, 503, 504, 522, 524, 408, 429],
         "USER_AGENT": "mediacloud bot for open academic research (+https://mediacloud.org)",
+        "DOWNLOAD_TIMEOUT": 60,  # reduce load from long wait times.
+        "DOWNLOADER_MIDDLEWARES": DOWNLOADER_MIDDLEWARES,
     }
 
     def __init__(


### PR DESCRIPTION
Two changes- 
1. Add custom timeout, about half the duration of the default timeout.
2. Add a new Redirect Middleware which checks for non_news_domains in redirect urls before launching a redirect. 

Addressing issues in #134 (and #127) 