### PR TITLE
Proposed changes to deployment variables for elastic-snapshots service.

### DIFF
--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -300,17 +300,22 @@ services:
       <<: *worker-environment-vars
       RUN: rabbitmq-stats
 
-{% if elasticsearch_snapshot_cronjob_enable == 'true' %}
+{% if elasticsearch_snapshot_containers >= 0 %}
   # Elasticsearch Snaphost worker
   elastic-snapshots:
     <<: *worker-service-settings
     labels:
         swarm.cronjob.enable: "{{elasticsearch_snapshot_cronjob_enable}}"
-        swarm.cronjob.schedule: "0 0 * * *"
+        swarm.cronjob.replicas: 1
+        swarm.cronjob.schedule: "0 1 * * *"
+    deploy:
+      <<: *worker-deploy-settings
+      replicas: {{elasticsearch_snapshot_containers}}
     environment:
       <<: *worker-environment-vars
       RUN: elastic-snapshots
-      ELASTICSEARCH_SNAPSHOT_REPO: mediacloud-elasticsearch-snapshots
+      ARGS: "{{elasticsearch_snapshot_args}}"
+      ELASTICSEARCH_SNAPSHOT_REPO: {{elasticsearch_snapshot_repo}}
 {% endif %}
 
   ################ news search api (built elsewhere)


### PR DESCRIPTION
The point of this change set is to give more flexibility on when the elastic-snapshots container is launched.

0. Enhance "int" in deploy.sh to handle negative numbers
1. Add ELASTICSEARCH_SNAPSHOT_CONTAINERS (int)
     if < 0: shapshots disabled (default/dev)
     if = 0: do not launch when stack deployed (production)
     if > 0: launch at stack deployment
2. Add ELASTICSEARCH_SNAPSHOT_REPO (str)
3. Add ELASTICSEARCH_SNAPSHOT_ARGS (allow-empty) passed in ARGS (to allow extra args in staging, if needed, to define shapshot, load keys)
5. Change cronjob to run at 01:00GMT (allow time to redeploy stack after 00:00GMT)
6. Add swarm.cronjob.replicas: 1 (for production)