### PR TITLE
use errors="replace" in RawHTML html property method

### DIFF
--- a/indexer/story.py
+++ b/indexer/story.py
@@ -137,7 +137,7 @@ class RawHTML(StoryData):
             if self.encoding is None:
                 self.guess_encoding()
             assert isinstance(self.encoding, str)
-            return self.html.decode(self.encoding)
+            return self.html.decode(self.encoding, errors="replace")
 
 
 RAW_HTML = class_to_member_name(RawHTML)


### PR DESCRIPTION
'replace' means "Replace with a suitable replacement character" on decode error (was causing quarantine).  It looks like "suitable replacement" is unicode code point FFFD "REPLACEMENT CHARACTER" which displays as � (which is what, I think, most browsers do).

fixes https://github.com/mediacloud/story-indexer/issues/184