### PR TITLE
bump news-search-api to latest test build

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -115,7 +115,7 @@ FETCHER_OPTIONS="--yesterday"
 NEWS_SEARCH_API_PORT=8000	# native port
 NEWS_SEARCH_IMAGE_NAME=mcsystems/news-search-api
 NEWS_SEARCH_IMAGE_REGISTRY=docker.io/
-NEWS_SEARCH_IMAGE_TAG=v1.0.0b2
+NEWS_SEARCH_IMAGE_TAG=v1.0.0b3
 NEWS_SEARCH_UI_PORT=8501	# server's native port
 NEWS_SEARCH_UI_TITLE="News Search Query" # Explorer currently appended
 


### PR DESCRIPTION
Tiny change to bump news-search-api to latest version (v1.0.0b3)