### PR TITLE
Infrastructure for queuing/processing historical data and archives, and queue-based fetcher

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,22 +11,22 @@ repos:
       - id: check-json
       - id: check-toml
   - repo: http://github.com/ambv/black
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
       - id: black
         language_version: python3.10
   - repo: http://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         entry: bin/pre-commit-wrapper.py mypy
         additional_dependencies: ["pip==22.0.*"]
   - repo: http://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
   - repo: http://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/bin/run-arch-queuer.sh
+++ b/bin/run-arch-queuer.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. bin/func.sh
+
+run_python indexer.workers.arch-queuer "$@"

--- a/bin/run-hist-fetcher.sh
+++ b/bin/run-hist-fetcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. bin/func.sh
+
+run_python indexer.workers.hist-fetcher "$@"

--- a/bin/run-hist-queuer.sh
+++ b/bin/run-hist-queuer.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. bin/func.sh
+
+run_python indexer.workers.hist-queuer "$@"

--- a/docker/README.md
+++ b/docker/README.md
@@ -41,9 +41,20 @@ deploy before opening a PR.
 
 Your stack will be named <USERNAME>-indexer.
 
+#### logs
+
 To check the health and logs of specific service within the Swarm
 
     docker service logs <STACK>_process_name
+
+Log files from all containers are collected by the syslog-sink
+container in (container) /app/data/logs/messages.log (log files
+rotated hourly and retained for 14 days).
+
+The logs directory can be found outside docker as
+/var/lib/docker/volumes/<STACK>_worker_data/_data/logs
+
+#### viewing/managing services
 
 To list running services and container replica counts:
 
@@ -53,11 +64,16 @@ or
 
     docker service ls --filter name=<STACK>_
 
-To check that containers are not failing and being restarted,
-after a few minutes check `docker ps` output.
+To check that containers are not failing and being restarted, after a
+few minutes check `docker ps` output; `docker ps -a` will show
+`Exited` for containers that have terminated.
 
 A development deploy will fetch 5000 articles once
 (no restart at midnight GMT)
+
+To scale or stop a single service:
+
+    docker service scale SERVICE=NUMBER
 
 To remove your stack:
 
@@ -165,3 +181,15 @@ are supplied in all environments:
     ./docker/deploy.sh -B prod
 
 _PLB: (maybe make this part of the pre-commit checks? how??)_
+
+## Historical (S3 CSV & HTML) story processing
+
+An independent stack for processing historical data can be launched
+with `deploy.sh -T historical`, and the stack will be prefixed with
+`hist-`.
+
+## Archive (WARC file) story processing
+
+An independent stack for processing historical data can be launched
+with `deploy.sh -T archive`, and the stack will be prefixed with
+`arch-`.

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -358,7 +358,7 @@ fi
 if [ "x$IS_DIRTY" = x ]; then
     # use git tag for image tag.
     # in development this means old tagged images will pile up until removed
-    WORKER_IMAGE_TAG=$TAG
+    WORKER_IMAGE_TAG=$(echo $TAG | sed 's/[^a-zA-Z0-9_.-]/_/g')
 else
     # _could_ include DATE_TIME, but old images can be easily pruned:
     WORKER_IMAGE_TAG=$LOGIN_USER-dirty
@@ -595,7 +595,7 @@ fi
 
 if [ "x$BUILD_ONLY" = x ]; then
     echo ''
-    echo -n "Deploy from branch $BRANCH as stack $STACK_NAME? [no] "
+    echo -n "Deploy from branch $BRANCH stack $STACK_NAME ($PIPELINE_TYPE)? [no] "
     read CONFIRM
     case "$CONFIRM" in
     [yY]|[yY][eE][sS]) ;;

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -184,7 +184,7 @@ IMPORTER_ARGS=''
 # if adding anything here also add to indexer.pipeline.MyPipeline.pipe_layer method,
 # and to PIPELINE_TYPES (above the usage function)!
 
-# PIPE_TYPE_PFX effects stack (and service) name, volume directories
+# PIPE_TYPE_PFX effects stack (and service) name, volume directories, stats realm
 case "$PIPELINE_TYPE" in
 batch-fetcher)
     PIPE_TYPE_PFX=''
@@ -219,8 +219,9 @@ queue-fetcher)
     ;;
 esac
 
-# alter stack name based on pipeline type:
+# prefix stack name, stats realm with pipeline type:
 BASE_STACK_NAME=$PIPE_TYPE_PFX$BASE_STACK_NAME
+STATSD_REALM=$PIPE_TYPE_PFX$STATSD_REALM
 
 # check if in sync with remote
 # (send stderr to /dev/null in case remote branch does not exist)

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -196,7 +196,7 @@ batch-fetcher)
 historical)
     IMPORTER_ARGS=--no-output	# no archives (??)
     PIPE_TYPE_PFX='hist-'	# own stack name/queues
-    PIPE_TYPE_PORT_BIAS=100	# own port range
+    PIPE_TYPE_PORT_BIAS=200	# own port range (ES has 9200+9300)
     # maybe require command line option to select file(s)?
     QUEUER_FILES=s3://mediacloud-database-files/2023/stories_2023-12-06.csv
     QUEUER_TYPE='hist-queuer'	# name of run- script
@@ -204,7 +204,7 @@ historical)
 archive)
     IMPORTER_ARGS=--no-output	# no archives!!!
     PIPE_TYPE_PFX='arch-'	# own stack name/queues
-    PIPE_TYPE_PORT_BIAS=200	# own port range
+    PIPE_TYPE_PORT_BIAS=400	# own port range
     # maybe require command line option to select file(s)?
     QUEUER_FILES=s3://mediacloud-indexer-archive/2023/11/12/mc-20231112015211-1-a332941ae45f.warc.gz
     QUEUER_TYPE='arch-queuer'	# name of run- script

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -125,6 +125,8 @@ FETCHER_CRONJOB_ENABLE=true	# used for queuers too!
 FETCHER_REPLICAS=20
 FETCHER_OPTIONS="--yesterday"	# batch fetcher
 
+HIST_FETCHER_REPLICAS=4		# needs tuning
+
 NEWS_SEARCH_API_PORT=8000	# native port
 NEWS_SEARCH_IMAGE_NAME=mcsystems/news-search-api
 NEWS_SEARCH_IMAGE_REGISTRY=docker.io/
@@ -192,7 +194,6 @@ batch-fetcher)
     QUEUER_TYPE=''
     ;;
 historical)
-    FETCHER_REPLICAS=4		# needs tuning
     IMPORTER_ARGS=--no-output	# no archives (??)
     PIPE_TYPE_PFX='hist-'	# own stack name/queues
     PIPE_TYPE_PORT_BIAS=100	# own port range
@@ -524,6 +525,7 @@ fi
 add FETCHER_CRONJOB_ENABLE	# NOT bool! used by queuers too!!
 add FETCHER_REPLICAS int
 add FETCHER_OPTIONS		# batch-fetcher only (see QUEUER_ARGS)
+add HIST_FETCHER_REPLICAS int
 add IMPORTER_ARGS allow-empty
 add NETWORK_NAME
 add NEWS_SEARCH_API_PORT int

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -267,6 +267,8 @@ if [ "x$HIST_PFX" != x ]; then
     # offset exported ports by 100
     # (in addition to any biases for staging/dev)
     PORT_BIAS=$(expr $PORT_BIAS + 100)
+else
+    IMPORTER_ARGS=
 fi
 
 # NOTE! in-network containers see native (unmapped) ports,

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -16,10 +16,9 @@ BASE_STACK_NAME=indexer
 
 # in addition to developer/staging/production deployment types, there
 # are now pipeline types, set by -T for handling ingest of historical
-# or archival data.  They run as separate stacks, with private
+# or archival data.  They run as separate stacks, with their own
 # RabbitMQ servers so the data is not co-mingled, and back-fill can be
-# managed separately.  Within a instance type there is only one ES
-# server/cluster (all roads lead to Rome).
+# managed separately (ie; entirely shut down) at will.
 
 SCRIPT=$0
 SCRIPT_DIR=$(dirname $SCRIPT)

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -310,11 +310,6 @@ dev)
     ;;
 esac
 
-ELASTICSEARCH_PORT_BASE=$(expr $ELASTICSEARCH_PORT_BASE + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
-NEWS_SEARCH_API_PORT=$(expr $NEWS_SEARCH_API_PORT + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
-NEWS_SEARCH_UI_PORT=$(expr $NEWS_SEARCH_UI_PORT + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
-RABBITMQ_PORT=$(expr $RABBITMQ_PORT + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
-
 # NOTE! in-network containers see native (unmapped) ports,
 # so set environment variable values BEFORE applying PORT_BIAS!!
 if [ "x$RABBITMQ_CONTAINERS" = x0 ]; then
@@ -329,7 +324,8 @@ if [ "x$RABBITMQ_CONTAINERS" = x0 ]; then
 else
     RABBITMQ_HOST=rabbitmq
 fi
-RABBITMQ_URL="amqp://$RABBITMQ_HOST:$RABBITMQ_PORT$RABBITMQ_VHOST/?connection_attempts=10&retry_delay=5"
+# BEFORE biases applied!!
+RABBITMQ_URL="amqp://$RABBITMQ_HOST:$RABBITMQ_BASE_PORT$RABBITMQ_VHOST/?connection_attempts=10&retry_delay=5"
 
 if [ "x$ELASTICSEARCH_CONTAINERS" != x0 ]; then
     ELASTICSEARCH_HOSTS=http://elasticsearch1:$ELASTICSEARCH_PORT_BASE
@@ -393,6 +389,12 @@ if [ "x$QUEUER_TYPE" != x ]; then
 else
     QUEUER_ARGS=''
 fi
+
+# calculate exported port numbers using pipeline-type and deployment-type biases:
+ELASTICSEARCH_PORT_BASE_EXPORTED=$(expr $ELASTICSEARCH_PORT_BASE + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
+NEWS_SEARCH_API_PORT_EXPORTED=$(expr $NEWS_SEARCH_API_PORT + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
+NEWS_SEARCH_UI_PORT_EXPORTED=$(expr $NEWS_SEARCH_UI_PORT + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
+RABBITMQ_PORT_EXPORTED=$(expr $RABBITMQ_PORT + $PIPE_TYPE_PORT_BIAS + $PORT_BIAS)
 
 # some commands require docker-compose.yml in the current working directory:
 cd $SCRIPT_DIR
@@ -515,6 +517,7 @@ if [ "$ELASTICSEARCH_CONTAINERS" -gt 0 ]; then
     add ELASTICSEARCH_IMAGE
     add ELASTICSEARCH_PLACEMENT_CONSTRAINT
     add ELASTICSEARCH_PORT_BASE int
+    add ELASTICSEARCH_PORT_BASE_EXPORTED int
     add ELASTICSEARCH_NODES
 fi
 add FETCHER_CRONJOB_ENABLE	# NOT bool! used by queuers too!!
@@ -523,8 +526,10 @@ add FETCHER_OPTIONS		# batch-fetcher only (see QUEUER_ARGS)
 add IMPORTER_ARGS allow-empty
 add NETWORK_NAME
 add NEWS_SEARCH_API_PORT int
+add NEWS_SEARCH_API_PORT_EXPORTED int
 add NEWS_SEARCH_IMAGE
 add NEWS_SEARCH_UI_PORT int
+add NEWS_SEARCH_UI_PORT_EXPORTED int
 add NEWS_SEARCH_UI_TITLE
 add PIPELINE_TYPE
 add QUEUER_ARGS allow-empty
@@ -535,6 +540,7 @@ add QUEUER_TYPE allow-empty
 add PARSER_REPLICAS int
 add RABBITMQ_CONTAINERS int
 add RABBITMQ_PORT int
+add RABBITMQ_PORT_EXPORTED int
 add RABBITMQ_URL
 add SENTRY_DSN allow-empty	# private: empty to disable
 add SENTRY_ENVIRONMENT		# private

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -674,7 +674,7 @@ fi
 
 # TEMP OFF (only run if repo not localhost?)
 echo docker compose push:
-docker compose push
+docker compose push --quiet
 STATUS=$?
 if [ $STATUS != 0 ]; then
     echo docker compose push failed: $STATUS 1>&2

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -196,7 +196,7 @@ historical)
     PIPE_TYPE_PFX='hist-'	# own stack name/queues
     PIPE_TYPE_PORT_BIAS=100	# own port range
     # maybe require command line option to select file(s)?
-    QUEUER_FILES=s3://mediacloud-database-X-files/csv_files/YYYY_MM_
+    QUEUER_FILES=s3://mediacloud-database-files/2023/stories_2023-12-06.csv
     QUEUER_TYPE='hist-queuer'	# name of run- script
     ;;
 archive)
@@ -204,7 +204,7 @@ archive)
     PIPE_TYPE_PFX='arch-'	# own stack name/queues
     PIPE_TYPE_PORT_BIAS=200	# own port range
     # maybe require command line option to select file(s)?
-    QUEUER_FILES=s3://mediacloud-indexer-archive/2023/12/
+    QUEUER_FILES=s3://mediacloud-indexer-archive/2023/11/12/mc-20231112015211-1-a332941ae45f.warc.gz
     QUEUER_TYPE='arch-queuer'	# name of run- script
     ;;
 queue-fetcher)
@@ -319,13 +319,12 @@ if [ "x$RABBITMQ_CONTAINERS" = x0 ]; then
     # queue namespace (would want to clear PIPE_TYPE_BIAS for
     # RABBITMQ_PORT!), and have index.pipeline "configure" make sure
     # vhost exists.
-    echo "RABBITMQ_CONTAINERS is zero: need RABBITMQ_HOST!!!" 1>&2
+    echo "RABBITMQ_CONTAINERS is zero: need RABBITMQ_(V)HOST!!!" 1>&2
     exit 1
 else
     RABBITMQ_HOST=rabbitmq
 fi
-# BEFORE biases applied!!
-RABBITMQ_URL="amqp://$RABBITMQ_HOST:$RABBITMQ_BASE_PORT$RABBITMQ_VHOST/?connection_attempts=10&retry_delay=5"
+RABBITMQ_URL="amqp://$RABBITMQ_HOST:$RABBITMQ_PORT$RABBITMQ_VHOST/?connection_attempts=10&retry_delay=5"
 
 if [ "x$ELASTICSEARCH_CONTAINERS" != x0 ]; then
     ELASTICSEARCH_HOSTS=http://elasticsearch1:$ELASTICSEARCH_PORT_BASE

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -192,6 +192,7 @@ batch-fetcher)
     QUEUER_TYPE=''
     ;;
 historical)
+    FETCHER_REPLICAS=4		# needs tuning
     IMPORTER_ARGS=--no-output	# no archives (??)
     PIPE_TYPE_PFX='hist-'	# own stack name/queues
     PIPE_TYPE_PORT_BIAS=100	# own port range

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -179,7 +179,6 @@ prod|staging)
     ;;
 esac
 
-FETCHER_OPTIONS=--yesterday	# batch fetcher
 IMPORTER_ARGS=''
 
 # if adding anything here also add to indexer.pipeline.MyPipeline.pipe_layer method,
@@ -383,11 +382,12 @@ NETWORK_NAME=$STACK_NAME
 # construct QUEUER_ARGS for {arch,hist,rss}-queuers
 if [ "x$QUEUER_TYPE" != x ]; then
     if [ "x$STORY_LIMIT" != x ]; then
-	QUEUER_ARGS="--force --max-stories $STORY_LIMIT"
+	# pick random sample:
+	QUEUER_ARGS="--force --sample-size $STORY_LIMIT"
     fi
     QUEUER_ARGS="$QUEUER_ARGS $QUEUER_FILES"
 else
-    QUEUER_ARGS=''
+    QUEUER_ARGS='N/A'
 fi
 
 # calculate exported port numbers using pipeline-type and deployment-type biases:
@@ -532,7 +532,7 @@ add NEWS_SEARCH_UI_PORT int
 add NEWS_SEARCH_UI_PORT_EXPORTED int
 add NEWS_SEARCH_UI_TITLE
 add PIPELINE_TYPE
-add QUEUER_ARGS allow-empty
+add QUEUER_ARGS
 add QUEUER_S3_ACCESS_KEY_ID	# private
 add QUEUER_S3_REGION		# private
 add QUEUER_S3_SECRET_ACCESS_KEY # private

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -504,7 +504,7 @@ add DEPLOYMENT_DATE_TIME	   # for context
 add DEPLOYMENT_GIT_HASH		   # for context
 add DEPLOYMENT_HOST		   # for context
 add DEPLOYMENT_ID		   # for RabbitMQ sentinal
-add DEPLOYMENT_OPTIONS		   # for context
+add DEPLOYMENT_OPTIONS allow-empty # for context
 add DEPLOYMENT_USER		   # for context
 add ELASTICSEARCH_CLUSTER
 add ELASTICSEARCH_CONTAINERS int

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -41,6 +41,7 @@ if [ "x$(which jinja2)" = x ]; then
     fi
 fi
 
+PIPELINE_TYPES="batch-fetcher, historical, archive, queue-fetcher"
 usage() {
     echo "Usage: $SCRIPT [options]"
     echo "options:"
@@ -54,7 +55,8 @@ usage() {
     echo "  -u      allow running as non-root user"
     exit 1
 }
-PIPELINE_TYPE=batch-fetcher
+
+PIPELINE_TYPE=batch-fetcher	# default
 while getopts B:abdhinT:u OPT; do
    case "$OPT" in
    a) INDEXER_ALLOW_DIRTY=1;; # allow default from environment!
@@ -176,8 +178,9 @@ esac
 
 IMPORTER_ARGS=''
 
-# if adding anything here also add to indexer.pipeline.MyPipeline.pipe_layer method
-PIPELINE_TYPES="batch-fetcher, historical, archive, queue-fetcher"
+# if adding anything here also add to indexer.pipeline.MyPipeline.pipe_layer method,
+# and to PIPELINE_TYPES (above the usage function)!
+
 # PIPE_PFX effects stack (and service) name, volume directories
 case "$PIPELINE_TYPE" in
 batch-fetcher)

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -5,13 +5,20 @@
 # 1. add it to staging & prod configs too!!!
 # 2. add an "add VARIABLE # private" line to deploy.sh
 # 3. expand {{variable}} in docker-compose.yml.j2
+#	(typically as VARIABLE: {{variable}})
 #
 # PLEASE KEEP IN SORTED ORDER!!!
 #
+# used by archiver.py
 ARCHIVER_S3_ACCESS_KEY_ID=AKxxxxxx
 ARCHIVER_S3_BUCKET=NO_ARCHIVE	# magical: leave temp files in place
-ARCHIVER_S3_REGION=	# MUST be empty to disable S3 / check for "NO_ARCHIVE" bucket
+ARCHIVER_S3_REGION=  # MUST be empty to disable S3 / check for "NO_ARCHIVE" bucket
 ARCHIVER_S3_SECRET_ACCESS_KEY=..........
+#
+# used by {arch,hist,rss}-queuer.py (read only)
+QUEUER_S3_ACCESS_KEY_ID=AKxxxxxx
+QUEUER_S3_REGION=us-east-1
+QUEUER_S3_SECRET_ACCESS_KEY=..........
 #
 # SENTRY only enabled when SENTRY_DSN is non-empty
 SENTRY_DSN=

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -238,9 +238,25 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: configure-pipeline
-      ARGS: "configure_and_loop"
+      ARGS: "--type {{pipeline_type}} configure_and_loop"
 
-{% if fetcher_type == 'current' %}
+{% if queuer_type != '' %}
+  {{queuer_type}}:
+    <<: *worker-service-settings
+    deploy:
+      <<: *worker-deploy-settings
+      labels:
+         swarm.cronjob.enable: "{{fetcher_cronjob_enable}}"
+         swarm.cronjob.schedule: "45 0 * * *"
+      replicas: 1
+    environment:
+      <<: *worker-environment-vars
+      RUN: {{queuer_type}}
+      ARGS: "{{queuer_args}}"
+{% endif %}
+
+{% if pipeline_type == 'batch-fetcher' %}
+  # scrapy batch-based fetcher:
   fetcher-worker:
     <<: *worker-service-settings
     deploy:
@@ -248,32 +264,53 @@ services:
       labels:
          swarm.cronjob.enable: "{{fetcher_cronjob_enable}}"
          swarm.cronjob.schedule: "0 0 * * *"
-         swarm.cronjob.replicas: {{fetcher_num_batches}}
-      replicas: {{fetcher_num_batches}}
+         swarm.cronjob.replicas: {{fetcher_replicas}}
+      replicas: {{fetcher_replicas}}
     environment:
       <<: *worker-environment-vars
       RUN: fetcher
-      ARGS: "{{fetcher_options}} --num-batches={{fetcher_num_batches}} --batch-index={{ '{{.Task.Slot}}' }}"
-{% elif fetcher_type == 'hist-s3-csv' %}
-  # stuff here for hist-s3-fetcher service
-{% elif fetcher_type == 'warc' %}
-  # stuff here to fetch and process WARC archives
+      ARGS: "{{fetcher_options}} --num-batches={{fetcher_replicas}} --batch-index={{ '{{.Task.Slot}}' }}"
+{% elif pipeline_type == 'historical' %}
+  # fetches historical articles from S3, using Stories queued by hist-queuer:
+  hist-fetcher:
+    <<: *worker-service-settings
+    deploy:
+      <<: *worker-deploy-settings
+      replicas: {{fetcher_replicas}}
+    environment:
+      <<: *worker-environment-vars
+      RUN: hist-fetcher
+{% elif pipeline_type == 'queue-fetcher' %}
+  # queue-based HTTP fetcher, using Stories queued by rss-queuer:
+  queue-fetcher:
+    <<: *worker-service-settings
+    deploy:
+      <<: *worker-deploy-settings
+    environment:
+      <<: *worker-environment-vars
+      RUN: queue-fetcher
+      # pass ARGS: -Wn based on fetcher_replicas??
+{% elif pipeline_type == 'archive' %}
+   # no fetcher for loading archives (yet, anyway)
+   # hopefully archives have enough stories in each one
+   # to keep pipeline busy.
 {% endif %}
 
   parser-worker:
     <<: *worker-service-settings
     deploy:
       <<: *worker-deploy-settings
-      replicas: 4
+      replicas: {{parser_replicas}}
     environment:
       <<: *worker-environment-vars
       # Run py3lang/numpy/openblas dot operator single threaded:
       OPENBLAS_NUM_THREADS: 1
       RUN: parser
 
-  # PB: if running rabbitmq cluster (process on each ES node) w/ Docker
-  # have numbered service instances: importer-workerN,
-  # each tied to corresponding storage node?
+  # Have at least one importer-worker running on each storage node
+  # (connecting only to the local ES process)?
+  # If RabbitMQ cluster running (on each storage node)
+  # have the importer connect only to the local RabbitMQ??
   importer-worker:
     <<: *worker-service-settings
     # run multiple replicas? on es nodes??

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -240,6 +240,7 @@ services:
       RUN: configure-pipeline
       ARGS: "configure_and_loop"
 
+{% if fetcher_type == 'current' %}
   fetcher-worker:
     <<: *worker-service-settings
     deploy:
@@ -253,6 +254,11 @@ services:
       <<: *worker-environment-vars
       RUN: fetcher
       ARGS: "{{fetcher_options}} --num-batches={{fetcher_num_batches}} --batch-index={{ '{{.Task.Slot}}' }}"
+{% elif fetcher_type == 'hist-s3-csv' %}
+  # stuff here for hist-s3-fetcher service
+{% elif fetcher_type == 'warc' %}
+  # stuff here to fetch and process WARC archives
+{% endif %}
 
   parser-worker:
     <<: *worker-service-settings
@@ -274,6 +280,7 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: importer
+      ARGS: {{importer_args}}
       ELASTICSEARCH_REPLICAS: {{elasticsearch_importer_replicas}}
       ELASTICSEARCH_SHARDS: {{elasticsearch_importer_shards}}
 
@@ -287,33 +294,6 @@ services:
       ARCHIVER_S3_REGION: {{archiver_s3_region}}
       ARCHIVER_S3_ACCESS_KEY_ID: {{archiver_s3_access_key_id}}
       ARCHIVER_S3_SECRET_ACCESS_KEY: {{archiver_s3_secret_access_key}}
-
-  ################ historical parse/import pipeline (separate queues)
-
-  # no hist-fetcher container (yet?)
-
-  hist-parser-worker:
-    <<: *worker-service-settings
-    deploy:
-      <<: *worker-deploy-settings
-      replicas: 4
-    environment:
-      <<: *worker-environment-vars
-      # Run py3lang/numpy/openblas dot operator single threaded:
-      OPENBLAS_NUM_THREADS: 1
-      PROCESS_NAME: hist-parser
-      RUN: parser
-
-  hist-importer-worker:
-    <<: *worker-service-settings
-    environment:
-      <<: *worker-environment-vars
-      # archiving disabled (no process in importer/pipeline.py)
-      ARGS: "--no-output"
-      ELASTICSEARCH_REPLICAS: {{elasticsearch_importer_replicas}}
-      ELASTICSEARCH_SHARDS: {{elasticsearch_importer_shards}}
-      PROCESS_NAME: hist-importer
-      RUN: importer
 
   ################ stats reporters
 

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -298,9 +298,9 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: hist-fetcher
-      ARCHIVER_S3_REGION: {{archiver_s3_region}}
-      ARCHIVER_S3_ACCESS_KEY_ID: {{archiver_s3_access_key_id}}
-      ARCHIVER_S3_SECRET_ACCESS_KEY: {{archiver_s3_secret_access_key}}
+      QUEUER_S3_ACCESS_KEY_ID: {{queuer_s3_access_key_id}}
+      QUEUER_S3_REGION: {{queuer_s3_region}}
+      QUEUER_S3_SECRET_ACCESS_KEY: {{queuer_s3_secret_access_key}}
 {% elif pipeline_type == 'queue-fetcher' %}
   # queue-based HTTP fetcher, using Stories queued by rss-queuer:
   queue-fetcher:

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -255,14 +255,16 @@ services:
       ARGS: "--type {{pipeline_type}} configure_and_loop"
 
 {% if queuer_type != '' %}
+  # hist-queuer, arch-queuer, rss-queuer
   {{queuer_type}}:
     <<: *worker-service-settings
     deploy:
       <<: *worker-deploy-settings
       labels:
-         swarm.cronjob.enable: "{{fetcher_cronjob_enable}}"
-         swarm.cronjob.schedule: "45 0 * * *"
-      replicas: 1
+         swarm.cronjob.enable: "{{queuer_cronjob_enable}}"
+         swarm.cronjob.schedule: "0 3-59/5 * * * *" {# sec min hr DOM mon DOW #}
+         swarm.cronjob.replicas: {{queuer_cronjob_replicas}}
+      replicas: {{queuer_initial_replicas}}
     environment:
       <<: *worker-environment-vars
       RUN: {{queuer_type}}
@@ -270,9 +272,7 @@ services:
       QUEUER_S3_ACCESS_KEY_ID: {{queuer_s3_access_key_id}}
       QUEUER_S3_REGION: {{queuer_s3_region}}
       QUEUER_S3_SECRET_ACCESS_KEY: {{queuer_s3_secret_access_key}}
-
 {% endif %}
-
 {% if pipeline_type == 'batch-fetcher' %}
   # scrapy batch-based fetcher:
   fetcher-worker:
@@ -282,12 +282,12 @@ services:
       labels:
          swarm.cronjob.enable: "{{fetcher_cronjob_enable}}"
          swarm.cronjob.schedule: "0 0 * * *"
-         swarm.cronjob.replicas: {{fetcher_replicas}}
-      replicas: {{fetcher_replicas}}
+         swarm.cronjob.replicas: {{fetcher_num_batches}}
+      replicas: {{fetcher_num_batches}}
     environment:
       <<: *worker-environment-vars
       RUN: fetcher
-      ARGS: "{{fetcher_options}} --num-batches={{fetcher_replicas}} --batch-index={{ '{{.Task.Slot}}' }}"
+      ARGS: "{{fetcher_options}} --num-batches={{fetcher_num_batches}} --batch-index={{ '{{.Task.Slot}}' }}"
 {% elif pipeline_type == 'historical' %}
   # fetches historical articles from S3, using Stories queued by hist-queuer:
   hist-fetcher:

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -294,7 +294,7 @@ services:
     <<: *worker-service-settings
     deploy:
       <<: *worker-deploy-settings
-      replicas: {{fetcher_replicas}}
+      replicas: {{hist_fetcher_replicas}}
     environment:
       <<: *worker-environment-vars
       RUN: hist-fetcher
@@ -312,9 +312,10 @@ services:
       RUN: queue-fetcher
       # pass ARGS: -Wn based on fetcher_replicas??
 {% elif pipeline_type == 'archive' %}
-   # No fetcher for loading archives (yet, anyway).  Hopefully each
-   # archive has enough stories to keep pipeline busy enough not to
-   # need parallel fetching.
+   # No fetcher for loading archives (yet, anyway).
+   # arch-queuer reads archives directly and queues stories.
+   # Hopefully, each archive has enough stories to keep
+   # pipeline busy enough not to need parallel fetching.
 {% endif %}
 
   parser-worker:

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -107,6 +107,7 @@ x-worker-service-settings: &worker-service-settings
 
   environment: &worker-environment-vars
     <<: *base-environment-vars
+    DEPLOYMENT_ID: {{deployment_id}}
     ELASTICSEARCH_HOSTS: {{elasticsearch_hosts}}
     LOG_LEVEL: "info"
     RABBITMQ_URL: {{rabbitmq_url}}
@@ -253,6 +254,10 @@ services:
       <<: *worker-environment-vars
       RUN: {{queuer_type}}
       ARGS: "{{queuer_args}}"
+      QUEUER_S3_ACCESS_KEY_ID: {{queuer_s3_access_key_id}}
+      QUEUER_S3_REGION: {{queuer_s3_region}}
+      QUEUER_S3_SECRET_ACCESS_KEY: {{queuer_s3_secret_access_key}}
+
 {% endif %}
 
 {% if pipeline_type == 'batch-fetcher' %}
@@ -280,6 +285,9 @@ services:
     environment:
       <<: *worker-environment-vars
       RUN: hist-fetcher
+      ARCHIVER_S3_REGION: {{archiver_s3_region}}
+      ARCHIVER_S3_ACCESS_KEY_ID: {{archiver_s3_access_key_id}}
+      ARCHIVER_S3_SECRET_ACCESS_KEY: {{archiver_s3_secret_access_key}}
 {% elif pipeline_type == 'queue-fetcher' %}
   # queue-based HTTP fetcher, using Stories queued by rss-queuer:
   queue-fetcher:
@@ -291,9 +299,9 @@ services:
       RUN: queue-fetcher
       # pass ARGS: -Wn based on fetcher_replicas??
 {% elif pipeline_type == 'archive' %}
-   # no fetcher for loading archives (yet, anyway)
-   # hopefully archives have enough stories in each one
-   # to keep pipeline busy.
+   # No fetcher for loading archives (yet, anyway).  Hopefully each
+   # archive has enough stories to keep pipeline busy enough not to
+   # need parallel fetching.
 {% endif %}
 
   parser-worker:

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -261,7 +261,7 @@ services:
       replicas: 4
     environment:
       <<: *worker-environment-vars
-      # Run numpy dot operator single threaded:
+      # Run py3lang/numpy/openblas dot operator single threaded:
       OPENBLAS_NUM_THREADS: 1
       RUN: parser
 
@@ -287,6 +287,33 @@ services:
       ARCHIVER_S3_REGION: {{archiver_s3_region}}
       ARCHIVER_S3_ACCESS_KEY_ID: {{archiver_s3_access_key_id}}
       ARCHIVER_S3_SECRET_ACCESS_KEY: {{archiver_s3_secret_access_key}}
+
+  ################ historical parse/import pipeline (separate queues)
+
+  # no hist-fetcher container (yet?)
+
+  hist-parser-worker:
+    <<: *worker-service-settings
+    deploy:
+      <<: *worker-deploy-settings
+      replicas: 4
+    environment:
+      <<: *worker-environment-vars
+      # Run py3lang/numpy/openblas dot operator single threaded:
+      OPENBLAS_NUM_THREADS: 1
+      PROCESS_NAME: hist-parser
+      RUN: parser
+
+  hist-importer-worker:
+    <<: *worker-service-settings
+    environment:
+      <<: *worker-environment-vars
+      # archiving disabled (no process in importer/pipeline.py)
+      ARGS: "--no-output"
+      ELASTICSEARCH_REPLICAS: {{elasticsearch_importer_replicas}}
+      ELASTICSEARCH_SHARDS: {{elasticsearch_importer_shards}}
+      PROCESS_NAME: hist-importer
+      RUN: importer
 
   ################ stats reporters
 

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -45,6 +45,16 @@ version: "3.8"
  # (declared inline under foo-service-settings)
  #}
 
+# context:
+# stack_name: {{stack_name}}
+# deployment_branch: {{deployment_branch}}
+# deployment_date_time: {{deployment_date_time}}
+# deployment_git_hash: {{deployment_git_hash}}
+# deployment_host: {{deployment_host}}
+# deployment_options: {{deployment_options}}
+# deployment_user: {{deployment_user}}
+# pipeline_type: {{pipeline_type}}
+
 ################ common settings for all services
 
 x-base-service-settings: &base-service-settings

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -226,6 +226,8 @@ services:
         condition: none
     image: {{elasticsearch_image}}
     user: root
+    volumes:
+      - *es-backup-volume
 
 {% for i in range(1,elasticsearch_containers+1) %}
   elasticsearch{{i}}:

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -100,6 +100,9 @@ x-es-service-settings: &es-service-settings
       hard: -1
 
 # common volume for elasticsearch containers
+# (would be nice to declare default volumes list above,
+# but YAML doesn't have a list merge operator (like <<: does for mappings)
+# see https://github.com/yaml/yaml/issues/48)
 x-es-backup-volume: &es-backup-volume "elasticsearch_data_backup:/var/backups/elasticsearch"
 {% endif %}
 
@@ -206,8 +209,8 @@ services:
     hostname: rabbitmq
     image: rabbitmq:3.11-management-alpine
     ports:
-      - "{{rabbitmq_port}}:5672"
-      - "{{rabbitmq_port+10000}}:15672"
+      - "{{rabbitmq_port_exported}}:{{rabbitmq_port}}"
+      - "{{rabbitmq_port_exported+10000}}:{{rabbitmq_port+10000}}"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
 {% endif %}
@@ -223,8 +226,6 @@ services:
         condition: none
     image: {{elasticsearch_image}}
     user: root
-    volumes:
-      - *es-backup-volume
 
 {% for i in range(1,elasticsearch_containers+1) %}
   elasticsearch{{i}}:
@@ -233,9 +234,9 @@ services:
       <<: *es-environment-vars
       node.name: elasticsearch{{i}}
     ports:
-      {% set port9200mapping = elasticsearch_port_base + i - 1 -%}
-      - {{port9200mapping}}:9200
-      - {{port9200mapping+100}}:9300
+      {% set port9200mapping = elasticsearch_port_base_exported + i - 1 -%}
+      - {{port9200mapping}}:{{elasticsearch_port_base}}
+      - {{port9200mapping+100}}:{{elasticsearch_port_base+100}}
     volumes:
       - *es-backup-volume
       - elasticsearch_data_{{"%02d" % i}}:/usr/share/elasticsearch/data
@@ -409,7 +410,7 @@ services:
       TERMAGGRS: top,significant,rare
       TERMFIELDS: article_title,text_content
     ports:
-      - {{news_search_api_port}}:8000
+      - {{news_search_api_port_exported}}:{{news_search_api_port}}
 
   news-search-ui:
     <<: *news-search-service-settings
@@ -419,7 +420,7 @@ services:
       APIURL: http://news-search-api:8000/v1
       TITLE: {{news_search_ui_title}}
     ports:
-      - {{news_search_ui_port}}:8501
+      - {{news_search_ui_port_exported}}:{{news_search_ui_port}}
 
 {% macro define_volume(prefix, suffix='') %}
   {{prefix}}{{suffix}}:

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -37,9 +37,10 @@ class AppException(RuntimeError):
     """
 
 
-class ArgsProtocol(Protocol):
+class AppProtocol(Protocol):
     """
-    class for "self" in App mixins that declare & access command line args
+    class for "self" in App mixins that declare & access command line args,
+    or want access to stats
     """
 
     args: Optional[argparse.Namespace]
@@ -47,8 +48,20 @@ class ArgsProtocol(Protocol):
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         ...
 
+    def incr(self, name: str, value: int = 1, labels: Labels = []) -> None:
+        ...
 
-class App(ArgsProtocol):
+    def gauge(self, name: str, value: float, labels: Labels = []) -> None:
+        ...
+
+    def timing(self, name: str, ms: float, labels: Labels = []) -> None:
+        ...
+
+    def timer(self, name: str) -> "_TimingContext":
+        ...
+
+
+class App(AppProtocol):
     """
     Base class for command line applications (ie; Worker)
     """
@@ -365,7 +378,7 @@ class _TimingContext:
         self.t0 = -1.0
 
 
-class IntervalMixin(ArgsProtocol):
+class IntervalMixin(AppProtocol):
     """
     Mixin for Apps that report stats at a fixed interval
     """

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -391,11 +391,18 @@ class IntervalMixin(ArgsProtocol):
         time.sleep(sleep_sec)
 
 
+def run(klass: type[App], *args: Any, **kw: Any) -> None:
+    """
+    run app process
+    """
+    app = klass(*args, **kw)
+    app.main()
+
+
 if __name__ == "__main__":
 
     class Test(App):
         def main_loop(self) -> None:
             print("here")
 
-    t = Test("test", "test of app class")
-    t.main()
+    run(Test, "test", "test of app class")

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -48,6 +48,9 @@ class AppProtocol(Protocol):
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         ...
 
+    def process_args(self) -> None:
+        ...
+
     def incr(self, name: str, value: int = 1, labels: Labels = []) -> None:
         ...
 

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -54,7 +54,9 @@ class App(ArgsProtocol):
     """
 
     def __init__(self, process_name: str, descr: str):
-        self.process_name = process_name
+        # override of process_name allow alternate versions of pipeline
+        # (ie; processing historical data) from different queues
+        self.process_name = os.environ.get("PROCESS_NAME", process_name)
         self.descr = descr
         self.args: Optional[argparse.Namespace] = None  # set by main
         self._statsd: Optional[statsd.StatsdClient] = None

--- a/indexer/app.py
+++ b/indexer/app.py
@@ -419,6 +419,11 @@ if __name__ == "__main__":
 
     class Test(App):
         def main_loop(self) -> None:
-            print("here")
+            # allow testing of --help, --debug, --log-level
+            logger.critical("critical")
+            logger.error("error")
+            logger.warning("warning")
+            logger.info("info")
+            logger.debug("debug")
 
     run(Test, "test", "test of app class")

--- a/indexer/blobstore/S3.py
+++ b/indexer/blobstore/S3.py
@@ -29,6 +29,5 @@ class S3Store(indexer.blobstore.BlobStore):
         )
 
     def store_from_local_file(self, local_path: str, remote_path: str) -> None:
-        if self.s3.upload_file(local_path, self.s3_bucket, remote_path):
-            return
-        raise S3Error("upload_file returned False")
+        # mypy says it doesn't return a value:
+        self.s3.upload_file(local_path, self.s3_bucket, remote_path)

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -14,17 +14,17 @@ from urllib.parse import urlparse
 from elastic_transport import NodeConfig, ObjectApiResponse
 from elasticsearch import Elasticsearch
 
-from indexer.app import ArgsProtocol
+from indexer.app import AppProtocol
 
 logger = getLogger(__name__)
 
 
-class ElasticMixin:
+class ElasticMixin(AppProtocol):
     """
     mixin class for Apps that use Elastic Search API
     """
 
-    def define_options(self: ArgsProtocol, ap: argparse.ArgumentParser) -> None:
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
 
         ap.add_argument(
@@ -34,7 +34,7 @@ class ElasticMixin:
             help="comma separated list of ES server URLs",
         )
 
-    def elasticsearch_client(self: ArgsProtocol) -> Elasticsearch:
+    def elasticsearch_client(self) -> Elasticsearch:
         assert self.args
         hosts = self.args.elasticsearch_hosts
         if not hosts:

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -8,10 +8,7 @@ import argparse
 import os
 import sys
 from logging import getLogger
-from typing import Any, List, Optional
-from urllib.parse import urlparse
 
-from elastic_transport import NodeConfig, ObjectApiResponse
 from elasticsearch import Elasticsearch
 
 from indexer.app import AppProtocol

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -347,4 +347,9 @@ if __name__ == "__main__":
             )
         ],
     )
+    # second pipeline for historical data, without archiver
+    p.add_producer(
+        "hist-fetcher",
+        [p.add_worker("hist-parser", [p.add_consumer("hist-importer")])],
+    )
     p.main()

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -330,7 +330,7 @@ class Pipeline(QApp):
             name = q["name"]
             msgs = q["messages"]
             bytes = q["message_bytes"]
-            print(f"{name:16.16s} {msgs:9d} msgs {bytes:9d} bytes")
+            print(f"{name:20.20s} {msgs:9d} msgs {bytes:9d} bytes")
 
     @command
     def show(self) -> None:

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -151,7 +151,6 @@ class Pipeline(QApp):
         ap.add_argument("command", nargs=1, type=str, choices=COMMANDS, help="Command")
         ap.add_argument(
             "--type",
-            nargs=1,
             type=str,
             choices=self.PIPE_TYPES,
             help=f"pipeline type (default: {self.DEFAULT_TYPE})",
@@ -369,6 +368,8 @@ class MyPipeline(Pipeline):
         assert self.args
         pt = self.args.type
 
+        logger.info("pipe type: %s", pt)
+
         importer = self.add_worker("importer", [self.add_consumer("archiver")])
         # parse/import/archive
         p_i_a = self.add_worker("parser", [importer])
@@ -379,7 +380,7 @@ class MyPipeline(Pipeline):
             self.add_producer("fetcher", [p_i_a])
         elif pt == "queue-fetcher":
             self.add_producer(
-                "queue-rss", [self.add_worker("fetcher", [p_i_a], fast_delay=True)]
+                "rss-queuer", [self.add_worker("fetcher", [p_i_a], fast_delay=True)]
             )
         elif pt == "historical":
             self.add_producer("hist-queuer", [self.add_worker("hist-fetcher", [p_i_a])])

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -6,12 +6,10 @@ But wait, this file is also a script for configuring
 the default pipeline.... It's a floor wax AND a desert topping!
 
 https://www.nbc.com/saturday-night-live/video/shimmer-floor-wax/2721424
-"""
 
-# PLB: Maybe this should write out RabbitMQ configuration file
-# (instead of configuring queues) so that RabbitMQ comes up configured
-# on restart?!!! *BUT* this assumes there is ONE true configuration
-# (ie; that any queues for backfill processing are included).
+With the addition of the --type option, it seems to have taken a turn
+to be a utility, rather than a library...
+"""
 
 import argparse
 import logging
@@ -255,7 +253,16 @@ class Pipeline(QApp):
         #### _configure function body:
 
         if not create:
-            self._set_configured(chan, False)  # MUST be first!!!
+            # MUST be first!!!
+            # remove semaphore
+            # (do this regardless?)
+            self._set_configured(chan, False)
+
+        # XXX maybe delete should remove everything
+        # (keep non-empty queues unless --force'ed?)
+
+        # XXX maybe remove exchanges before creating any
+        # (or at least confirm that existing ones should be kept)?
 
         # create queues and exchanges
         for name, proc in self.procs.items():
@@ -365,6 +372,9 @@ class MyPipeline(Pipeline):
     def lay_pipe(self) -> None:
         """
         define pipeline topology
+
+        NOTE!  Any major rearrangement of routing (bindings)
+        likely requires removing old bindings first!!
         """
         assert self.args
         pt = self.args.type

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -319,11 +319,22 @@ class Pipeline(QApp):
         print("Commands (use --help for options):")
         for cmd in COMMANDS:
             descr = self.get_command_func(cmd).__doc__
-            print(f"{cmd:12.12} {descr}")
+            print(f"{cmd:20.20s} {descr}")
+
+    @command
+    def qlen(self) -> None:
+        """show queue lengths"""
+        api = self.admin_api()
+        queues = api._api_get("/api/queues")
+        for q in queues:
+            name = q["name"]
+            msgs = q["messages"]
+            bytes = q["message_bytes"]
+            print(f"{name:16.16s} {msgs:9d} msgs {bytes:9d} bytes")
 
     @command
     def show(self) -> None:
-        """show queues"""
+        """show queues, exchanges, bindings"""
         defns = self.get_definitions()
         for what in ("queues", "exchanges", "bindings"):
             things = defns[what]

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -358,7 +358,7 @@ class Pipeline(QApp):
 
 
 class MyPipeline(Pipeline):
-    PIPE_TYPES = ["batch-fetcher", "queue-fetcher", "historical", "warc"]
+    PIPE_TYPES = ["batch-fetcher", "queue-fetcher", "historical", "archive"]
     DEFAULT_TYPE = "batch-fetcher"
 
     def lay_pipe(self) -> None:

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -15,6 +15,7 @@ https://www.nbc.com/saturday-night-live/video/shimmer-floor-wax/2721424
 
 import argparse
 import logging
+import os
 import sys
 from typing import Any, Callable, Dict, List, Set, Union, cast
 

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -13,12 +13,10 @@ to be a utility, rather than a library...
 
 import argparse
 import logging
-import os
 import sys
-from typing import Any, Callable, Dict, List, Set, Union, cast
+from typing import Callable, Dict, List, Union, cast
 
 # PyPI
-import pika
 from pika.exchange_type import ExchangeType
 
 # local:

--- a/indexer/pipeline.py
+++ b/indexer/pipeline.py
@@ -339,17 +339,15 @@ if __name__ == "__main__":
     # or "python indexer/pipeline.py"
     # configure the default queues.
     p = Pipeline("pipeline", "configure story-indexer queues")
-    p.add_producer(
-        "fetcher",
-        [
-            p.add_worker(
-                "parser", [p.add_worker("importer", [p.add_consumer("archiver")])]
-            )
-        ],
+
+    # parse/import/archive
+    p_i_a = p.add_worker(
+        "parser", [p.add_worker("importer", [p.add_consumer("archiver")])]
     )
-    # second pipeline for historical data, without archiver
-    p.add_producer(
-        "hist-fetcher",
-        [p.add_worker("hist-parser", [p.add_consumer("hist-importer")])],
-    )
+
+    # create exchanges to route outputs to regular parse/import/archive chain
+    p.add_producer("fetcher", [p_i_a])
+    p.add_producer("hist-fetcher", [p_i_a])
+    #   p.add_producer("warc-fetcher", [p_i_a])
+
     p.main()

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -379,7 +379,7 @@ class Queuer(StoryProducer):
             args.force
             or args.max_stories is not None
             or args.random_sample is not None
-            or args.text
+            or args.test
         )
         try:
             tracker = get_tracker(self.process_name, fname, testing)

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 class Queuer(StoryProducer):
-    MAX_QUEUE = 100000  # don't queue if dest longer than this
+    MAX_QUEUE_LEN = 100000  # don't queue if (any) dest queue longer than this
 
     AWS_PREFIX: str  # prefix for environment vars
 
@@ -70,10 +70,10 @@ class Queuer(StoryProducer):
             help="don't queue stories",
         )
         ap.add_argument(
-            "--max-queue",
+            "--max-queue-len",
             type=int,
-            default=self.MAX_QUEUE,
-            help=f"Maximum queue length at which to send a new batch (default: {self.MAX_QUEUE})",
+            default=self.MAX_QUEUE_LEN,
+            help=f"Maximum queue length at which to send a new batch (default: {self.MAX_QUEUE_LEN})",
         )
         ap.add_argument(
             "--max-stories",
@@ -85,7 +85,7 @@ class Queuer(StoryProducer):
             "--loop",
             action="store_true",
             default=False,
-            help="Run until all files processed (sleeping if needed)",
+            help="Run until all files processed (sleeping if needed), else process one file and quit.",
         )
 
         self.input_group = ap.add_argument_group()

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -25,6 +25,7 @@ import gzip
 import io
 import logging
 import os
+import random
 import sys
 import tempfile
 import time
@@ -96,6 +97,12 @@ class Queuer(StoryProducer):
             default=False,
             help="Run until all files processed (sleeping if needed), else process one file and quit.",
         )
+        ap.add_argument(
+            "--random-sample",
+            type=float,
+            default=None,
+            help="Percentage of stories queue (default: all)",
+        )
 
         self.input_group = ap.add_argument_group()
         assert self.input_group is not None
@@ -115,6 +122,10 @@ class Queuer(StoryProducer):
 
         if self.args.dry_run:
             status = "parsed"
+        if self.args.random_sample is not None and (
+            random.random() * 100 > self.args.random_sample
+        ):
+            status = "dropped"
         else:
             if self.sender is None:
                 self.sender = self.story_sender()

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -87,7 +87,10 @@ class Queuer(StoryProducer):
         assert self.input_group is not None
         self.input_group.add_argument("input_files", nargs="*", default=None)
 
-    def queue_story(self, story: BaseStory) -> None:
+    def incr_stories(self, status: str) -> None:
+        self.incr("stories", labels=[("status", status)])
+
+    def send_story(self, story: BaseStory) -> None:
         assert self.args
         if self.args.dry_run:
             return
@@ -95,7 +98,7 @@ class Queuer(StoryProducer):
             self.sender = self.story_sender()
         self.sender.send_story(story)
         self.queued_stories += 1
-        self.incr("stories")
+        self.incr_stories("success")
         if (
             self.args.max_stories is not None
             and self.queued_stories >= self.args.max_stories

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -29,13 +29,15 @@ import sys
 import tempfile
 import time
 from enum import Enum
-from typing import Any, BinaryIO, List, Optional, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, List, Optional, cast
 
 import boto3
 import botocore
 import requests
 import urllib3
-from mypy_boto3_s3.client import S3Client
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
 
 from indexer.app import AppException
 from indexer.story import BaseStory

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -57,7 +57,7 @@ class Queuer(StoryProducer):
 
     HANDLE_GZIP: bool  # True to intervene if .gz present
 
-    SAMPLE_PERCENT = 0.1  # for --sample-size
+    SAMPLE_PERCENT = 10.0  # for --sample-size
 
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -1,0 +1,248 @@
+"""
+Queuer: a StoryProducer class for reading (possibly remote) input
+files, processing them, and queuing Stories for "fetching"
+
+Supports http(s) and S3 file sources, with limited S3 "globbing"
+
+Uses "indexer.tracker" to keep track of already processed files.
+
+Made into a class because several input paths need the same logic:
+1. Historical Ingest: reading CSV files of db dumps, fetching HTTP from S3
+2. Queue based fetcher: reading rss-fetcher generated RSS files
+3. Reading and replaying WARC archive files
+
+By default will loop for all files on command line (checking queue
+lengths and sleeping).  Alternative "one-file" mode finds at most one
+file to process and exits, which is (more) suitable for use from a
+crontab.
+"""
+
+import argparse
+import gzip
+import io
+import logging
+import os
+import sys
+import tempfile
+import time
+from enum import Enum
+from typing import Any, List, Optional, Tuple
+
+import boto3
+import botocore
+import requests
+import urllib3
+from mypy_boto3_s3.client import S3Client
+
+from indexer.app import AppException
+from indexer.tracker import TrackerException, get_tracker
+from indexer.worker import BaseStory, StoryProducer, StorySender
+
+logger = logging.getLogger(__name__)
+
+
+class Queuer(StoryProducer):
+    MAX_QUEUE = 100000
+
+    AWS_PREFIX: str  # prefix for environment vars
+
+    def __init__(self, process_name: str, descr: str):
+        super().__init__(process_name, descr)
+        self.input_group: Optional[argparse._ArgumentGroup] = None
+        self.sender: Optional[StorySender] = None
+        self.queued_stories = 0
+        self.s3_client_object: Optional[S3Client] = None
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+
+        ap.add_argument(
+            "--dry-run",
+            "-n",
+            action="store_true",
+            default=False,
+            help="don't queue stories",
+        )
+        ap.add_argument(
+            "--max-queue",
+            type=int,
+            default=self.MAX_QUEUE,
+            help=f"Maximum queue length at which to send a new batch (default: {self.MAX_QUEUE})",
+        )
+        ap.add_argument(
+            "--max-stories",
+            type=int,
+            default=None,
+            help="Number of stories to queue. Default (None) is 'all of them'",
+        )
+        ap.add_argument(
+            "--one-file",
+            "-1",  # digit one
+            action="store_true",
+            default=False,
+            help="Try at most one file and quit; for crontab use",
+        )
+
+        self.input_group = ap.add_argument_group()
+        assert self.input_group is not None
+        self.input_group.add_argument("input_files", nargs="*", default=None)
+
+    def queue_story(self, story: BaseStory) -> None:
+        assert self.args
+        if self.args.dry_run:
+            return
+        if self.sender is None:
+            self.sender = self.story_sender()
+        self.sender.send_story(story)
+        self.queued_stories += 1
+        self.incr("stories")
+        if (
+            self.args.max_stories is not None
+            and self.queued_stories >= self.args.max_stories
+        ):
+            logger.info("queued %s stories; quitting", self.queued_stories)
+            sys.exit(0)
+
+    def process_file(self, fname: str, fobj: io.IOBase) -> None:
+        """
+        Override, calling "self.queue_story" for each Story
+        NOTE! fobj is a binary file!
+        Wrap with TextIOWrapper for reading strings
+        """
+        raise NotImplementedError("process_file not overridden")
+
+    def check_output_queues(self) -> None:
+        """
+        snooze while output queue(s) have enough work;
+        if in "try one and quit" (crontab) mode, just quit.
+        """
+
+        assert self.args
+        max_queue = self.args.max_queue
+
+        # get list of queues fed from this app's output exchange
+        admin = self.admin_api()
+        defns = admin.get_definitions()
+        output_exchange = self.output_exchange_name
+        queue_names = set(
+            [
+                binding["destination"]
+                for binding in defns["bindings"]
+                if binding["source"] == output_exchange
+            ]
+        )
+
+        while True:
+            # also wanted/used by scripts.rabbitmq-stats:
+            queues = admin._api_get("/api/queues")
+            for q in queues:
+                name = q["name"]
+                if name in queue_names:
+                    ready = q["messages_ready"]
+                    logger.debug("%s: ready %d", name, ready)
+                    if ready > max_queue:
+                        break
+            else:
+                # here when all queues short enough
+                return
+
+            if self.args and self.args.one_file:
+                logger.info("queue(s) full enough: quitting")
+                sys.exit(0)
+            logger.debug("sleeping until output queue(s) shorter")
+            time.sleep(60)
+
+    def s3_client(self) -> S3Client:
+        if not self.s3_client_object:
+            app = self.AWS_PREFIX.upper()
+            # NOTE! None values should default to using ~/.aws/credentials
+            # for command line debug/test.
+            region = os.environ.get(f"{app}_S3_REGION")
+            access_key_id = os.environ.get(f"{app}_S3_ACCESS_KEY_ID")
+            secret_access_key = os.environ.get(f"{app}_S3_SECRET_ACCESS_KEY")
+            self.s3_client_object = boto3.client(
+                "s3",
+                region_name=region,
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_access_key,
+            )
+        return self.s3_client_object
+
+    def split_s3_url(self, objname: str) -> List[str]:
+        # assumes s3:// prefix: returns at most two items
+        return objname[5:].split("/", 1)
+
+    def open_file(self, fname: str) -> io.IOBase:
+        if fname.startswith("http:") or fname.startswith("https:"):
+            resp = requests.get(fname)
+            if resp and resp.status_code == 200:
+                assert isinstance(resp.raw, urllib3.response.HTTPResponse)
+                return resp.raw
+            raise AppException(str(resp))
+
+        if fname.startswith("s3://"):
+            bucket, objname = self.split_s3_url(fname)
+            s3 = self.s3_client()
+            # anonymous temp file: maybe cache in named file?
+            tmpf = tempfile.TemporaryFile()
+            s3.download_fileobj(bucket, objname, tmpf)
+            tmpf.seek(0)  # rewind
+            return tmpf
+
+        return open(fname, "rb")
+
+    def maybe_process_files(self, fname: str) -> None:
+        """
+        supports simple prefix matching for s3 URLs
+        """
+        if fname.startswith("s3://") and fname.endswith("*"):
+            bucket, prefix = self.split_s3_url(fname[:-1])
+            s3 = self.s3_client()
+
+            marker = ""  # try handling pagination
+            while True:
+                res = s3.list_objects(Bucket=bucket, Prefix=prefix, Marker=marker)
+                for item in res["Contents"]:
+                    key = item["Key"]
+                    logger.info("key %s", key)
+                    self.maybe_process_file(f"s3://{bucket}/{key}")
+                if not res["IsTruncated"]:
+                    break
+                marker = key  # see https://github.com/boto/boto3/issues/470
+                logger.info("object list truncated; next marker: %s", marker)
+                if not marker:
+                    break
+        else:
+            self.maybe_process_file(fname)
+
+    def maybe_process_file(self, fname: str) -> None:
+        # wait until queue(s) low enough, or quit:
+        self.check_output_queues()
+
+        def incr_files(status: str) -> None:
+            self.incr("files", labels=[("status", status)])
+
+        try:
+            tracker = get_tracker(self.process_name, fname)
+            try:
+                with tracker:
+                    f = self.open_file(fname)
+                    logger.info("process_file %s", fname)
+                    self.process_file(fname, f)
+                incr_files("success")
+                if self.args and self.args.one_file:
+                    sys.exit(0)
+            except RuntimeError as e:  # YIKES!!!
+                logger.error("%s failed: %r", fname, e)
+                incr_files("failed")
+                # XXX re-raise???
+        except TrackerException as exc:
+            # here if file state other than "NOT_STARTED"
+            logger.info("%s: %r", fname, exc)
+            return
+
+    def main_loop(self) -> None:
+        assert self.args
+        # command line items may include S3 wildcards
+        for item in self.args.input_files:
+            self.maybe_process_files(item)

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -39,6 +39,8 @@ import urllib3
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
+else:
+    S3Client = Any
 
 from indexer.app import AppException
 from indexer.story import BaseStory
@@ -101,7 +103,8 @@ class Queuer(StoryProducer):
             "--random-sample",
             type=float,
             default=None,
-            help="Percentage of stories queue (default: all)",
+            metavar="PERCENT",
+            help="Percentage of stories to queue for testing (default: all)",
         )
 
         self.input_group = ap.add_argument_group()

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -29,13 +29,10 @@ import random
 import sys
 import tempfile
 import time
-from enum import Enum
 from typing import TYPE_CHECKING, Any, BinaryIO, Generator, List, Optional, cast
 
 import boto3
-import botocore
 import requests
-import urllib3
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -103,20 +103,19 @@ class Queuer(StoryProducer):
                 return  # logged and counted
 
         if self.args.dry_run:
-            self.incr_stories("dry-run", url)
-            return
-
-        if self.sender is None:
-            self.sender = self.story_sender()
-
-        self.sender.send_story(story)
-        self.incr_stories("success", url)  # AFTER send_story return
+            status = "parsed"
+        else:
+            if self.sender is None:
+                self.sender = self.story_sender()
+            self.sender.send_story(story)
+            status = "success"
         self.queued_stories += 1
+        self.incr_stories(status, url)
         if (
             self.args.max_stories is not None
             and self.queued_stories >= self.args.max_stories
         ):
-            logger.info("queued %s stories; quitting", self.queued_stories)
+            logger.info("%s %s stories; quitting", status, self.queued_stories)
             sys.exit(0)
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:

--- a/indexer/scripts/docker-stats.py
+++ b/indexer/scripts/docker-stats.py
@@ -8,7 +8,7 @@ Must:
 
 import argparse
 from logging import getLogger
-from typing import Any, Dict
+from typing import Dict
 
 import docker.client  # mypy doesn't see from_env in top module
 

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -5,11 +5,9 @@ report Elastic Search stats to statsd
 # Phil, from rabbitmq-stats.py
 # with help from importer
 
-import argparse
-import time
 from collections import Counter
 from logging import getLogger
-from typing import Any, Dict, List, cast
+from typing import Dict, List, cast
 
 from elastic_transport import ConnectionError, ConnectionTimeout
 

--- a/indexer/scripts/qutil.py
+++ b/indexer/scripts/qutil.py
@@ -22,7 +22,8 @@ from pika.spec import Basic, Queue
 
 from indexer.story import BaseStory
 from indexer.story_archive_writer import StoryArchiveReader, StoryArchiveWriter
-from indexer.worker import DEFAULT_ROUTING_KEY, QApp, StorySender
+from indexer.storyapp import StorySender
+from indexer.worker import DEFAULT_ROUTING_KEY, QApp
 
 logger = getLogger("qutil")
 

--- a/indexer/scripts/qutil.py
+++ b/indexer/scripts/qutil.py
@@ -13,12 +13,12 @@ import socket
 import sys
 from logging import getLogger
 from types import FrameType
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Callable, List, Optional, cast
 
 # PyPI
 from pika import BasicProperties
-from pika.adapters.blocking_connection import BlockingChannel, BlockingConnection
-from pika.spec import Basic, Queue
+from pika.adapters.blocking_connection import BlockingChannel
+from pika.spec import Basic
 
 from indexer.story import BaseStory
 from indexer.story_archive_writer import StoryArchiveReader, StoryArchiveWriter

--- a/indexer/scripts/qutil.py
+++ b/indexer/scripts/qutil.py
@@ -64,6 +64,13 @@ class QUtil(QApp):
     #### commands (in alphabetical order, docstring is help)
 
     @command
+    def delete(self) -> None:
+        q = self.get_queue()  # takes command line argument
+        chan = self.get_channel()
+        resp = chan.queue_delete(queue=q)
+        print(resp)
+
+    @command
     def dump_archives(self) -> None:
         """dump messages as archive files"""
 

--- a/indexer/scripts/rabbitmq-stats.py
+++ b/indexer/scripts/rabbitmq-stats.py
@@ -7,8 +7,6 @@ Report RabbitMQ stats
 # which uses
 # https://github.com/KristjanTammekivi/rabbitmq-admin
 
-import argparse
-import time
 from logging import getLogger
 from socket import gaierror  # DNS errors
 from typing import Any, Dict

--- a/indexer/scripts/syslog-sink.py
+++ b/indexer/scripts/syslog-sink.py
@@ -10,9 +10,7 @@ NOT an "App" (they all log to this program!)
 
 import logging
 import os
-import re
 import socket
-import sys
 from logging.handlers import SysLogHandler
 from typing import Tuple
 

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -11,9 +11,9 @@ import datetime as dt
 import json
 import os
 import time
-from io import BufferedReader, BytesIO
+from io import BytesIO
 from logging import getLogger
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, BinaryIO, Dict, Iterator, Optional, Tuple, Union
 
 from warcio.archiveiterator import ArchiveIterator
 from warcio.statusandheaders import StatusAndHeaders
@@ -337,7 +337,7 @@ class StoryArchiveWriter:
 
 
 class StoryArchiveReader:
-    def __init__(self, fileobj: BufferedReader):
+    def __init__(self, fileobj: BinaryIO):
         self.iterator = ArchiveIterator(fileobj)
 
     def read_stories(self) -> Iterator[BaseStory]:

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -1,0 +1,324 @@
+"""
+Story specific QApp stuff, split from worker.py
+"""
+
+# NOTE!!!! This file has been CAREFULLY coded to NOT assume consumers
+# are recieving messages from exactly one channel/queue:
+# * There is no channel global/member!!!
+# * The code DOES assume there is only one Pika connection.
+# * For code processing messages: Pika ops MUST be done from Pika thread
+
+import argparse
+import logging
+import os
+import queue
+import sys
+import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import SplitResult, urlsplit
+
+from mcmetadata.urls import NON_NEWS_DOMAINS
+from pika.adapters.blocking_connection import BlockingChannel
+
+from indexer.app import AppProtocol
+from indexer.story import BaseStory
+from indexer.worker import (
+    CONSUMER_TIMEOUT_SECONDS,
+    DEFAULT_ROUTING_KEY,
+    InputMessage,
+    QApp,
+    Worker,
+)
+
+# 10Mb- > 99.99% of pages should fit under this limit.
+MAX_HTML_BYTES = int(os.environ.get("MAX_HTML_BYTES", 10000000))
+
+logger = logging.getLogger(__name__)
+
+
+def non_news_fqdn(fqdn: str) -> bool:
+    """
+    check if a FQDN (fully qualified domain name, ie; DNS name)
+    is (in) a domain embargoed as "non-news"
+
+    maybe belongs in  mcmetadata??
+    """
+    # could be written as "any" on a comprehension:
+    # looks like that's 15% slower in Python 3.10,
+    # and harder to for me to... comprehend!
+    fqdn = fqdn.lower()
+    for nnd in NON_NEWS_DOMAINS:
+        if fqdn == nnd or fqdn.endswith("." + nnd):
+            return True
+    return False
+
+
+class StoryMixin(AppProtocol):
+    """
+    The place for Story-specific methods for both
+    StoryProducers (output only) and Workers (in/out)
+    """
+
+    def incr_stories(
+        self, status: str, url: str, log_level: int = logging.INFO
+    ) -> None:
+        """
+        Should be called exactly once for each Story processed.
+        default level is INFO so logs track disposition of every story.
+        """
+        # All stats are prefixed by app name, so visible as
+        # counters.mc.APP.stories.status_X or across all apps as
+        # counters.mc.*.stories.status_X
+        # (so try to use the same status strings across apps!)
+        self.incr("stories", labels=[("status", status)])
+
+        # could send to a sub-logger (__name__ + '.stories')
+        logger.log(log_level, "%s: %s", status, url)
+
+    def check_story_length(self, html: bytes, url: str) -> bool:
+        """
+        check HTML length:
+        False return means a counter has been incremented and URL logged
+        and the Story should be discarded.
+        """
+        if not html:
+            self.incr_stories("no-html", url)
+            return False
+
+        if len(html) > MAX_HTML_BYTES:
+            self.incr_stories("oversized", url)
+            return False
+
+        return True
+
+    def check_story_url(self, url: str) -> bool:
+        """
+        check URL.
+        False return means a counter has been incremented and URL logged,
+        and the Story should be discarded.
+
+        Ideally: call when queuing a new Story, and for each intermediate
+        redirect URL while fetching.
+        """
+        if not url:
+            self.incr_stories("no-url", url)
+            return False
+
+        # XXX check for over-sized URL??
+        # rss-fetcher's default limit is 2048
+
+        # using urlsplit/SplitResult: parseurl calls spliturl and only
+        # adds ";params" handling and this code only cares about netinfo
+        try:
+            surl = urlsplit(url, allow_fragments=False)
+        except ValueError:
+            self.incr_stories("bad-url", url)
+            return False
+
+        hostname = surl.hostname
+        if not hostname:
+            self.incr_stories("no-host", url)
+            return False
+
+        # check for schema?
+
+        if non_news_fqdn(hostname):
+            self.incr_stories("non-news", url)
+            return False
+
+        return True
+
+
+class StorySender:
+    """
+    object to hide channel.
+
+    Stories must be sent on the channel they came in on to make
+    transmission of new message and ACK of original atomic with
+    tx_commit.
+    """
+
+    def __init__(self, app: QApp, channel: BlockingChannel):
+        self.app = app
+        self._channel = channel
+
+    def send_story(
+        self,
+        story: BaseStory,
+        exchange: Optional[str] = None,
+        routing_key: str = DEFAULT_ROUTING_KEY,
+    ) -> None:
+        self.app._send_message(self._channel, story.dump(), exchange, routing_key)
+
+
+class StoryProducer(StoryMixin, QApp):
+    """
+    QApp that queues new Story objects
+    """
+
+    def story_sender(self) -> StorySender:
+        """
+        MUST be called after qconnect, before Pika thread running
+        """
+        assert self.connection
+        assert self._pika_thread is None
+        return StorySender(self, self.connection.channel())
+
+
+class StoryWorker(StoryMixin, Worker):
+    """
+    Process Stories in Queue Messages
+    """
+
+    def __init__(self, process_name: str, descr: str):
+        super().__init__(process_name, descr)
+
+        # avoid needing to create senders on the fly
+        # for each incomming message.
+        self.senders: Dict[BlockingChannel, StorySender] = {}
+
+    def process_message(self, im: InputMessage) -> None:
+        chan = im.channel
+        if chan in self.senders:
+            sender = self.senders[chan]
+        else:
+            sender = self.senders[chan] = StorySender(self, chan)
+
+        # raised exceptions will cause retry; quarantine immediately?
+        story = BaseStory.load(im.body)
+
+        self.process_story(sender, story)
+
+    def process_story(self, sender: StorySender, story: BaseStory) -> None:
+        raise NotImplementedError("StoryWorker.process_story not overridden")
+
+
+class BatchStoryWorker(StoryWorker):
+    """
+    A worker processing batches of stories
+    (all stories consumed at once)
+    """
+
+    # Default values: just guesses, should be tuned.
+    # Can be overridden in subclass.
+    BATCH_SECONDS = 15 * 60  # time to wait for full batch
+    BATCH_SIZE = 5000  # max batch size
+    WORK_TIME = 5 * 60  # time to reserve for end_of_batch
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+
+        ap.add_argument(
+            "--batch-size",
+            type=int,
+            default=self.BATCH_SIZE,
+            help=f"set batch size in stories (default {self.BATCH_SIZE})",
+        )
+        ap.add_argument(
+            "--batch-seconds",
+            type=int,
+            default=self.BATCH_SECONDS,
+            help=f"set batch timeout in seconds (default {self.BATCH_SECONDS})",
+        )
+
+    def process_args(self) -> None:
+        super().process_args()
+
+        # leave a minimum of one minute for processing!!!
+        assert self.WORK_TIME < CONSUMER_TIMEOUT_SECONDS - 60
+        batch_seconds_max = CONSUMER_TIMEOUT_SECONDS - self.WORK_TIME
+
+        assert self.args
+        if self.args.batch_seconds > batch_seconds_max:
+            logger.error(
+                "--batch-seconds %d too large (must be <= %d)",
+                self.args.batch_seconds,
+                batch_seconds_max,
+            )
+            sys.exit(1)
+
+    def _qos(self, chan: BlockingChannel) -> None:
+        """
+        set "prefetch" limit: distributes messages among workers
+        processes, limits the number of unacked messages queued
+        """
+        assert self.args
+        chan.basic_qos(prefetch_count=self.args.batch_size)
+
+    def _process_messages(self) -> None:
+        """
+        Blocking loop for running Worker processing code on batches.
+        Processes messages queued by _on_message (called from Pika thread).
+        NOTE! Assumes all messages received on same channel!!
+        """
+        assert self.args
+        batch_size = int(self.args.batch_size)
+        batch_seconds = self.args.batch_seconds
+        batch_deadline = 0.0  # deadline for starting batch processing
+        batch_start_time = 0.0
+        msg_number = 1
+        msgs: List[InputMessage] = []
+
+        logger.info("batch_size %d, batch_seconds %d", batch_size, batch_seconds)
+        while self._running:
+            while msg_number <= batch_size:  # msg_number is one-based
+                if msg_number == 1:
+                    logger.info("waiting for first batch message")  # move to debug?
+                    im = self._message_queue.get()  # blocking
+                    batch_start_time = time.monotonic()  # for logging
+
+                    # base on when recieved from channel by Pika thread!!
+                    batch_deadline = im.mtime + batch_seconds
+                else:
+                    try:
+                        timeout = batch_deadline - time.monotonic()
+                        if timeout <= 0:
+                            break  # time is up! break batch loop
+                        logger.info(  # move to debug?
+                            "waiting %.3f seconds for batch message %d",
+                            timeout,
+                            msg_number,
+                        )
+                        im = self._message_queue.get(timeout=timeout)
+                    except queue.Empty:
+                        # exhausted the clock
+                        break  # break batch loop
+
+                if self._process_one_message(im):
+                    # only keep & count if processed ok
+                    msgs.append(im)
+                    msg_number += 1
+            # end of batch loop
+
+            # here with at least one message and time expired,
+            # or a full batch
+
+            logger.info(
+                "collected %d msg(s) in %.3f seconds",
+                len(msgs),
+                time.monotonic() - batch_start_time,
+            )
+            try:
+                with self.timer("batch"):
+                    self.end_of_batch()
+            except Exception as e:
+                # log as error, w/ exc_info=True?
+                logger.info("end_of_batch caught %r", e)
+
+                for im in msgs:
+                    self._retry(im, e)
+                self.incr("batches", labels=[("status", "retry")])
+
+            # all msgs must be from same channel!!
+            last_msg = msgs[-1]
+            assert last_msg
+            self._ack_and_commit(last_msg, multiple=True)
+            msg_number = 1
+            msgs = []
+
+        sys.stdout.flush()  # for redirection, supervisord
+        logger.info("_process_messages exiting")
+        sys.exit(1)  # give error status so docker restarts
+
+    def end_of_batch(self) -> None:
+        raise NotImplementedError("BatchStoryWorker.end_of_batch not overridden")

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -173,8 +173,14 @@ class StoryWorker(StoryMixin, Worker):
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
 
-        # avoid needing to create senders on the fly
-        # for each incomming message.
+        # avoid needing to create senders on the fly.
+        # Stories MUST be forwarded on the same channel they
+        # came in on for transactions to quarantee atomic forward+ack.
+        # NOTE: Currently only subscribing (chan.basic_consume)
+        # on a single channel, but if you want to take input from
+        # multiple queues, with different qos/prefetch values,
+        # this would be necessary, so implement it now,
+        # and avoid possible (if unlikely) surprise later.
         self.senders: Dict[BlockingChannel, StorySender] = {}
 
     def process_message(self, im: InputMessage) -> None:

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -14,8 +14,8 @@ import os
 import queue
 import sys
 import time
-from typing import Any, Dict, List, Optional
-from urllib.parse import SplitResult, urlsplit
+from typing import Dict, List, Optional
+from urllib.parse import urlsplit
 
 from mcmetadata.urls import NON_NEWS_DOMAINS
 from pika.adapters.blocking_connection import BlockingChannel

--- a/indexer/tracker.py
+++ b/indexer/tracker.py
@@ -1,8 +1,8 @@
 """
-keep track of queued files.
+Keep track of queued work files.
 
-isolates implementation of record keeping for queuers.
-would prefer something replicated/durable (S3, AWS SimpleDB, ES)
+Isolates implementation of record keeping for Queuers.
+Would prefer something replicated/durable (S3, AWS SimpleDB, ES)
 see https://github.com/mediacloud/story-indexer/issues/203
 """
 
@@ -65,7 +65,7 @@ class FileTracker:
         # look for "extension" suffixes associated with gzip and remove
         if "." in base:
             # get final "extension"
-            prefix, ext = base.rsplit(".")
+            prefix, ext = base.rsplit(".", 1)
             if ext.lower() in ("gz", "gzip"):
                 return prefix
         return base

--- a/indexer/tracker.py
+++ b/indexer/tracker.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Any, Callable, Type, cast
 
 from indexer.app import AppException
+from indexer.path import DATAROOT
 
 # basename assumes URLs and local paths both use "/":
 assert os.path.sep == "/"
@@ -107,7 +108,7 @@ class LocalFileTracker(FileTracker):
 
     def __init__(self, app_name: str, fname: str):
         super().__init__(app_name, fname)
-        self._app_data_dir = "/app/data"  # os.environ.get("APP_DATA")?
+        self._app_data_dir = DATAROOT()
         if not os.path.isdir(self._app_data_dir):
             logger.warning("%s directory not found", self._app_data_dir)
             self._app_data_dir = "."

--- a/indexer/tracker.py
+++ b/indexer/tracker.py
@@ -1,0 +1,123 @@
+"""
+keep track of queued files.
+
+isolates implementation of record keeping for queuers.
+would prefer something replicated/durable (S3, AWS SimpleDB, ES)
+see https://github.com/mediacloud/story-indexer/issues/203
+"""
+
+import dbm
+import logging
+import os
+import time
+from enum import Enum
+from typing import Any, Callable, Type, cast
+
+from indexer.app import AppException
+
+logger = logging.getLogger(__name__)
+
+
+class TrackerException(AppException):
+    """
+    thrown when file is in some state other than NOT_STARTED
+    """
+
+
+class FileStatus(Enum):
+    """
+    file status: values (except NOT_STARTED) may be thrown
+    as Exception by FileTracker __init__.
+    All values are instances of FileStatus
+    """
+
+    NOT_STARTED = 1
+    STARTED = 2  # processing started
+    EXPIRED = 3  # started, not finished in expected time
+    FINISHED = 4
+
+
+class FileTracker:
+    def __init__(self, app_name: str, fname: str):
+        self.app_name = app_name
+        self.fname = fname
+        # raise exception FileStatus.THING if status not NOT_STARTED??
+
+    def __enter__(self) -> "FileTracker":
+        self._set_status(FileStatus.STARTED)
+        return self
+
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
+        if traceback:
+            self._set_status(FileStatus.NOT_STARTED)
+        else:
+            self._set_status(FileStatus.FINISHED)
+        self._cleanup()
+
+    def _set_status(self, status: FileStatus) -> None:
+        raise NotImplementedError("_set_status not overridden")
+
+    def _cleanup(self) -> None:
+        raise NotImplementedError("_cleanup not overridden")
+
+
+class LocalFileTracker(FileTracker):
+    """
+    a file tracker that uses a local directory for data storage
+    """
+
+    def __init__(self, app_name: str, fname: str):
+        super().__init__(app_name, fname)
+        self._app_data_dir = "/app/data"  # os.environ.get("APP_DATA")?
+        if not os.path.isdir(self._app_data_dir):
+            logger.warning("%s directory not found", self._app_data_dir)
+            self._app_data_dir = "."
+        self._work_dir = os.path.join(self._app_data_dir, self.app_name)
+        if not os.path.isdir(self._work_dir):
+            os.mkdir(self._work_dir)
+
+
+class DBMFileTracker(LocalFileTracker):
+    """
+    HOPEFULLY TEMPORARY!!!
+    NOTE!!!! GDBM locks file for exclusive access!!
+    Will see:
+    _gdbm.error: [Errno 11] Resource temporarily unavailable
+
+    Local concurrent access is likely safe?
+    NFS access at your own risk/funeral.
+    """
+
+    def __init__(self, app_name: str, fname: str):
+        super().__init__(app_name, fname)
+        path = os.path.join(self._work_dir, "file-tracker.db")
+        # GDBM takes advisory lock!!! cleanup *MUST* be called!!!
+        self._dbm = dbm.open(path, "c", 0o644)
+        status, ts = self._dbm.get(fname, b"NOT_STARTED,0").decode().split(",")
+        if status != "NOT_STARTED":
+            self._cleanup()
+            raise TrackerException(getattr(FileStatus, status).name)
+
+    def _set_status(self, status: FileStatus) -> None:
+        if status == FileStatus.NOT_STARTED:
+            del self._dbm[self.fname]
+        else:
+            status_string = f"{status.name},{int(time.time())}"
+            self._dbm[self.fname] = status_string.encode()
+        sync = getattr(self._dbm, "sync")
+        if sync is not None:
+            csync = cast(Callable[[], None], sync)
+            csync()
+
+    def _cleanup(self) -> None:
+        """
+        NOTE! GDBM takes exclusive lock!!!
+        """
+        if self._dbm:
+            self._dbm.close()
+            del self._dbm
+
+
+def get_tracker(app_name: str, fname: str) -> FileTracker:
+    cls = DBMFileTracker  # complex decision process
+    return cls(app_name, fname)

--- a/indexer/tracker.py
+++ b/indexer/tracker.py
@@ -88,6 +88,18 @@ class FileTracker:
         raise NotImplementedError("_cleanup not overridden")
 
 
+class DummyFileTracker(FileTracker):
+    """
+    file tracker that never says no (for debug/test)
+    """
+
+    def _set_status(self, status: FileStatus) -> None:
+        pass
+
+    def _cleanup(self) -> None:
+        pass
+
+
 class LocalFileTracker(FileTracker):
     """
     a file tracker that uses a local directory for data storage
@@ -146,6 +158,11 @@ class DBMFileTracker(LocalFileTracker):
             del self._dbm
 
 
-def get_tracker(app_name: str, fname: str) -> FileTracker:
-    cls = DBMFileTracker  # complex decision process
+def get_tracker(app_name: str, fname: str, force: bool) -> FileTracker:
+    # complex decision process:
+    cls: Type[FileTracker]
+    if force:
+        cls = DummyFileTracker  # always says yes
+    else:
+        cls = DBMFileTracker
     return cls(app_name, fname)

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -375,8 +375,16 @@ class QApp(App):
         if self._pika_thread:
             if self._pika_thread.is_alive():
                 self._running = False
+
                 # Log message in case Pika thread hangs.
                 logger.info("Waiting for Pika thread to exit")
+
+                # wake up Pika thread:
+                def nop() -> None:
+                    logger.info("nop")
+
+                self._call_in_pika_thread(nop)
+
                 # could issue join with timeout.
                 self._pika_thread.join()
             self._pika_thread = None

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -119,6 +119,11 @@ def delay_queue_name(procname: str) -> str:
     return procname + "-delay"
 
 
+def fast_queue_name(procname: str) -> str:
+    """take process name, return fast delay queue name"""
+    return procname + "-fast"
+
+
 def base_queue_name(qname: str) -> str:
     """
     take a queue name, and return base (app) name
@@ -448,7 +453,7 @@ class Worker(QApp):
         super().__init__(process_name, descr)
         self._message_queue: queue.Queue[InputMessage] = queue.Queue()
 
-     def define_options(self, ap: argparse.ArgumentParser) -> None:
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
         ap.add_argument(
             "--from-quarantine",
             action="store_true",

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -15,12 +15,11 @@ Story-specific things are in storyworker.py
 import argparse
 import logging
 import os
-import pickle
 import queue
 import sys
 import threading
 import time
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Type
+from typing import Callable, Dict, NamedTuple, Optional, Tuple, Type
 
 import pika.credentials
 import pika.exceptions
@@ -34,7 +33,7 @@ from pika.connection import URLParameters
 from pika.spec import PERSISTENT_DELIVERY_MODE, Basic
 
 # story-indexer
-from indexer.app import App, AppException, run
+from indexer.app import App, AppException
 
 logger = logging.getLogger(__name__)
 

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -507,15 +507,14 @@ class Worker(QApp):
         set "prefetch" limit: distributes messages among workers
         processes, limits the number of unacked messages queued
         """
+        # double buffered: one to work on, one on deck
         chan.basic_qos(prefetch_count=2)
 
     def _process_messages(self) -> None:
         """
         Blocking loop for running Worker processing code.  Processes
         messages queued by _on_message (called from Pika thread).
-        _COULD_ run more than one thread processing messages, but
-        running multiple instances of the process is easier to see and
-        control.
+        May run in multiple threads!
         """
 
         while self._running:

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -666,6 +666,11 @@ class Worker(QApp):
         #    When setting per-message TTL expired messages can queue
         #    up behind non-expired ones until the latter are consumed
         #    or expired.
+        # ie; expiration only happens at head of queue (FIFO), and
+        # all messages must have uniform expiration.
+        #
+        # The alternative, the delayed-message-exchange plugin has many
+        # limitations (no clustering), and is not supported.
         expiration_ms_str = str(int(RETRY_DELAY_MINUTES * MS_PER_MINUTE))
 
         # send to retry delay queue via default exchange

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -640,8 +640,9 @@ class Worker(QApp):
         )
 
     def _retry(self, im: InputMessage, e: Exception) -> bool:
-        # XXX if debugging re-raise exception???
-
+        """
+        returns False if retries exhausted
+        """
         oh = im.properties.headers  # old headers
         if oh:
             retries = oh.get(RETRIES_HDR, 0)

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -33,7 +33,7 @@ from pika.connection import URLParameters
 from pika.spec import PERSISTENT_DELIVERY_MODE, Basic
 
 # story-indexer
-from indexer.app import App, AppException
+from indexer.app import App, AppException, run
 from indexer.story import BaseStory
 
 logger = logging.getLogger(__name__)
@@ -859,12 +859,3 @@ class BatchStoryWorker(StoryWorker):
 
     def end_of_batch(self) -> None:
         raise NotImplementedError("BatchStoryWorker.end_of_batch not overridden")
-
-
-def run(klass: type[App], *args: Any, **kw: Any) -> None:
-    """
-    run app process
-    could, in theory create threads or asyncio tasks.
-    """
-    worker = klass(*args, **kw)
-    worker.main()

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -454,6 +454,7 @@ class Worker(QApp):
         self._message_queue: queue.Queue[InputMessage] = queue.Queue()
 
     def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
         ap.add_argument(
             "--from-quarantine",
             action="store_true",
@@ -462,6 +463,7 @@ class Worker(QApp):
         )
 
     def process_args(self) -> None:
+        super().process_args()
         assert self.args
         if self.args.from_quarantine:
             self.input_queue_name = quarantine_queue_name(self.process_name)

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -638,7 +638,7 @@ class Worker(QApp):
         assert tag is not None
 
         def acker() -> None:
-            msglogger.info("ack and commit #%s", tag)
+            msglogger.debug("ack and commit #%s", tag)
 
             im.channel.basic_ack(delivery_tag=tag, multiple=multiple)
 

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -19,10 +19,12 @@ logger = logging.getLogger(__name__)
 
 
 class ArchiveQueuer(Queuer):
+    HANDLE_GZIP = False  # handled by warcio
+
     def process_file(self, fname: str, fobj: BinaryIO) -> None:
         reader = StoryArchiveReader(fobj)
         for story in reader.read_stories():
-            self.send_story(story)  # increments counter
+            self.send_story(story, check_html=True)
 
 
 if __name__ == "__main__":

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ArchiveQueuer(Queuer):
-    AWS_PREFIX = "ARCH"  # S3 env var prefix
+    AWS_PREFIX = "ARCHIVER"  # same as archiver.py
     HANDLE_GZIP = False  # handled by warcio
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -1,0 +1,29 @@
+"""
+Worker to read archive files, and queue.
+Can read from S3, http, and local, monitors output queue.
+"""
+
+import argparse
+import csv
+import io
+import logging
+import os
+import sys
+from typing import BinaryIO
+
+from indexer.app import run
+from indexer.queuer import Queuer
+from indexer.story_archive_writer import StoryArchiveReader
+
+logger = logging.getLogger(__name__)
+
+
+class ArchiveQueuer(Queuer):
+    def process_file(self, fname: str, fobj: BinaryIO) -> None:
+        reader = StoryArchiveReader(fobj)
+        for story in reader.read_stories():
+            self.send_story(story)  # increments counter
+
+
+if __name__ == "__main__":
+    run(ArchiveQueuer, "arch-queuer", "Read Archive files and queue")

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -1,6 +1,7 @@
 """
 Worker to read archive files, and queue.
-Can read from S3, http, and local, monitors output queue.
+Can read from S3, http, and local files.
+Keeps track of files already queued.
 """
 
 import argparse
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ArchiveQueuer(Queuer):
+    AWS_PREFIX = "ARCH"  # S3 env var prefix
     HANDLE_GZIP = False  # handled by warcio
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -4,12 +4,7 @@ Can read from S3, http, and local files.
 Keeps track of files already queued.
 """
 
-import argparse
-import csv
-import io
 import logging
-import os
-import sys
 from typing import BinaryIO
 
 from indexer.app import run

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -2,14 +2,11 @@
 Media Cloud Archiver Worker
 """
 
-import argparse
 import logging
 import os
 import socket
 import time
-from enum import Enum
-from io import BytesIO, RawIOBase
-from typing import List, Optional
+from typing import Optional
 
 import indexer.blobstore
 from indexer.app import run

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 
 import indexer.blobstore
 from indexer.app import run
+from indexer.path import DATAROOT
 from indexer.story import BaseStory
 from indexer.story_archive_writer import ArchiveStoryError, StoryArchiveWriter
 from indexer.storyapp import BatchStoryWorker, StorySender
@@ -36,7 +37,7 @@ class Archiver(BatchStoryWorker):
         self.archives = 0  # number of archives written
 
         # default to Docker worker volume so files persist if not uploaded
-        self.work_dir = os.environ.get("ARCHIVER_WORK_DIR", "/app/data/archiver")
+        self.work_dir = os.environ.get("ARCHIVER_WORK_DIR", DATAROOT() + "archiver")
 
     def process_args(self) -> None:
         super().process_args()

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -12,9 +12,11 @@ from io import BytesIO, RawIOBase
 from typing import List, Optional
 
 import indexer.blobstore
+from indexer.app import run
 from indexer.story import BaseStory
 from indexer.story_archive_writer import ArchiveStoryError, StoryArchiveWriter
-from indexer.worker import BatchStoryWorker, QuarantineException, StorySender, run
+from indexer.storyapp import BatchStoryWorker, StorySender
+from indexer.worker import QuarantineException
 
 logger = logging.getLogger("indexer.workers.archiver")
 

--- a/indexer/workers/fetcher/fetch_worker.py
+++ b/indexer/workers/fetcher/fetch_worker.py
@@ -11,8 +11,9 @@ import scrapy.utils.log
 from mcmetadata.urls import NON_NEWS_DOMAINS
 from scrapy.crawler import CrawlerProcess
 
+from indexer.app import run
 from indexer.story import BaseStory, StoryFactory
-from indexer.worker import StoryProducer, run
+from indexer.storyapp import StoryProducer, StoryWorker
 from indexer.workers.fetcher.batch_spider import BatchSpider
 from indexer.workers.fetcher.rss_utils import RSSEntry, batch_rss, fetch_daily_rss
 
@@ -150,7 +151,7 @@ class FetchWorker(StoryProducer):
         else:
             status_label = f"http-{http_meta.response_code//100}xx"
 
-        self.incr("stories", labels=[("status", status_label)])
+        self.incr_stories(status_label, http_meta.final_url or "")
 
     def main_loop(self) -> None:
         # Fetch and batch rss

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -9,13 +9,10 @@ objects/second, AND to make it so that crashes/interruptions in the
 fetch keep track of what has already been handled.
 """
 
-import argparse
-import csv
 import gzip
 import io
 import logging
 import os
-import sys
 from typing import Any, Dict, Optional
 
 import boto3

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -1,12 +1,11 @@
 """
-Read CSV of articles from legacy system, using HTML stored
-on Amazon S3, indexed by downloads_id, and queue for processing
+Fetch stories archived on s3 by downloads_id by legacy system
+using Stories created from CSV by hist-queuer
 
-TODO?
-Toss stories w/ domain name ending in member of NON_NEWS_DOMAINS
-Take s3 URL for input file
-Drop empty FILENAME.done turn on S3 for completed files?
-Take s3 URL for file w/ list of input files??
+TODO:
+handle database B/D overlap!
+check for HTML too large!!
+deal with non-utf8 files!
 """
 
 import argparse
@@ -21,12 +20,10 @@ from typing import Any, Dict, List, Optional, Tuple, TypedDict
 import boto3
 from mcmetadata.urls import NON_NEWS_DOMAINS
 
-from indexer.story import BaseStory, StoryFactory
-from indexer.worker import StoryProducer, run
+from indexer.story import BaseStory
+from indexer.worker import QuarantineException, StorySender, Worker, run
 
-logger = logging.getLogger(__name__)
-
-Story = StoryFactory()
+logger = logging.getLogger("hist-fetcher")
 
 # NOTE! Two database epochs (B & D) have overlapping download ids:
 # DB B: 2021-09-15 00:00:00.921164 thru 2021-11-11 00:02:17.402188?
@@ -35,20 +32,22 @@ Story = StoryFactory()
 # db-b/stories_2021_09_15.csv:
 # 2021-09-15 16:36:53.505277,2043951575,18710,3211617068,59843,https://www.businessinsider.com/eff-google-daily-stormer-2017-8#comments
 
-# attrs from boto (not necessarily story downloads):
-# downloads/3211617604 sbRmtvTcbmDH.dxWNcIBsmRz.ffbbosG 18620 2021-09-15T20:51:01
-# downloads/3211617605 dSQTc9dyyVj34GP7zMI0GfOFmEkaQE_K 13761 2021-09-15T20:50:59
-# downloads/3211617605 fKUnm9Sbr8Gt33FaY0gUoKxaq5J3kY1l 36 2021-12-27T05:11:47
+# DB  attrs from boto (not necessarily story downloads):
+# B   3211617604 sbRmtvTcbmDH.dxWNcIBsmRz.ffbbosG 18620 2021-09-15T20:51:01
+# B   3211617605 dSQTc9dyyVj34GP7zMI0GfOFmEkaQE_K 13761 2021-09-15T20:50:59
+# D   3211617605 fKUnm9Sbr8Gt33FaY0gUoKxaq5J3kY1l 36 2021-12-27T05:11:47
 # ....
-# downloads/3257240456 N5Bn9xkkeGgXI1BSSzl71hRi9eiHCMo8 5499 2021-10-16T08:53:20
-# downloads/3257240456 Vp_Qfu7Yo1QkZqWA4RRYu83h0PFoFLOz 8853 2022-01-25T15:47:27
-# downloads/3257240457 N4tYO8GEnt6_px8SHE9VYc5B5N9Yp_hN 36 2021-10-16T08:53:19
+# B   3257240456 N5Bn9xkkeGgXI1BSSzl71hRi9eiHCMo8 5499 2021-10-16T08:53:20
+# D   3257240456 Vp_Qfu7Yo1QkZqWA4RRYu83h0PFoFLOz 8853 2022-01-25T15:47:27
+# B   3257240457 N4tYO8GEnt6_px8SHE9VYc5B5N9Yp_hN 36 2021-10-16T08:53:19
 
 OVERLAP_START = 3211617605  # lowest dl_id w/ multiple versions?
-OVERLAP_END = 3257240456  # hightest dl_lid w/ multiple versions?
+OVERLAP_END = 3257240456  # highest dl_id w/ multiple versions?
 
-DB_B_END = "2021-11-12"  # latest possible data in DB B
+DB_B_START = "2021-09-15"  # earliest date in DB B
+DB_B_END = "2021-11-12"  # latest date in DB B
 DB_D_START = "2021-12-26"  # earliest possible date in DB D
+DB_D_END = "2022-01-26"
 
 DOWNLOADS_BUCKET = "mediacloud-downloads-backup"
 DOWNLOADS_PREFIX = "downloads/"
@@ -57,88 +56,96 @@ DOWNLOADS_PREFIX = "downloads/"
 MAX_HTML_SIZE = 10000000  # 10MB
 
 
-class HistFetcher(StoryProducer):
-    AUTO_CONNECT: bool = False
+class HistFetcher(Worker):
+    def __init__(self, process_name: str, descr: str):
+        super().__init__(process_name, descr)
 
-    def define_options(self, ap: argparse.ArgumentParser) -> None:
-        super().define_options(ap)
-        ap.add_argument("csv", help="CSV file of stories")
-        ap.add_argument(
-            "--count", type=int, default=4294967296, help="count of stories to queue"
-        )
-
-    def main_loop(self) -> None:
-        assert self.args
-
-        count = self.args.count
-
-        # XXX take keys from environment
+        # XXX use blobstore, or get keys from environment
         s3 = boto3.resource("s3")
-        bucket = s3.Bucket(DOWNLOADS_BUCKET)
+        self.bucket = s3.Bucket(DOWNLOADS_BUCKET)
 
-        self.qconnect()
-        sender = self.story_sender()
-        self.start_pika_thread()
+    def pick_version(self, dlid: int, s3path: str, fetch_date: Optional[str]) -> Any:
+        if dlid < OVERLAP_START or dlid > OVERLAP_END:
+            return None
 
-        # expect local file for now
-        with open(self.args.csv) as f:
-            for row in csv.DictReader(f):
-                # typ columns: collect_date,stories_id,media_id,downloads_id,feeds_id,[language,]url
-                logger.info("%r", row)
+        if fetch_date is None:
+            raise QuarantineException(f"{dlid}: no fetch_date")
 
-                url = row.get("url", None)
-                if not url:
-                    logger.error("no url: %r", row)
-                    # XXX counter?
-                    continue
+        if DB_B_START < fetch_date < DB_B_END:
+            fetch_epoch = "B"
+        elif DB_D_START < fetch_date < DB_D_END:
+            fetch_epoch = "D"
+        else:
+            raise QuarantineException(f"{dlid}: unknown epoch for {fetch_date}")
 
-                try:
-                    dlid = int(row.get("downloads_id") or "")
-                except (KeyError, ValueError):
-                    logger.error("bad downloads_id: %r", row)
-                    # XXX counter?
-                    continue
+        versions = self.bucket.object_versions.filter(Prefix=s3path, MaxKeys=1)
+        for version in versions:
+            if version.key != s3path:
+                break
 
-                if dlid >= OVERLAP_START and dlid <= OVERLAP_END:
-                    logger.error("download id %d in overlap region", dlid)
-                    # XXX need to retrieve available versions and pick!!
-                    continue
+            # Dict w/ VersionId, ContentLength, LastModified (datetime)
+            objdata = version.get()
 
-                # 2023 era legacy system always wrote UTF-8?
-                # need to revisit for older archives!!!!
-                # XXX test if S3 data decodes w/o errors!!!!!
-                encoding = "utf-8"
+            lmdate = objdata["LastModified"].isoformat(sep=" ")
 
-                story = Story()
-                with story.rss_entry() as rss:
-                    rss.link = url  # only used for logging
+            # ensure is string, fix return type??
+            vid = objdata["VersionId"]
 
-                with story.http_metadata() as hmd:
-                    hmd.final_url = url
+            logger.debug("dlid %d fd %s lm %s v %s", dlid, fetch_date, lmdate, vid)
 
-                with io.BytesIO() as bio:
-                    s3path = DOWNLOADS_PREFIX + str(dlid)
-                    bucket.download_fileobj(s3path, bio)
-                    html = gzip.decompress(bio.getbuffer())
+            # declare victory if both from same epoch
+            if fetch_epoch == "B" and DB_B_START < lmdate < DB_B_END:
+                return vid
 
-                logger.info("%s: %d bytes", url, len(html))
-                # XXX check length
-                with story.raw_html() as raw:
-                    raw.encoding = encoding
-                    raw.html = html
+            if fetch_epoch == "D" and DB_D_START < lmdate < DB_D_END:
+                return vid
 
-                lang = row.get("language", None)
-                if lang:
-                    with story.content_metadata() as cmd:
-                        cmd.language = cmd.full_language = lang
+        raise QuarantineException(f"{dlid}: epoch {fetch_epoch} no match?")
 
-                sender.send_story(story)
-                # counter?
+    def process_story(self, sender: StorySender, story: BaseStory) -> None:
+        rss = story.rss_entry()
 
-                count -= 1
-                if count <= 0:
-                    logger.info("reached max count")
-                    break
+        if rss.link:
+            # XXX inside try: Quarantine on error?
+            dlid = int(rss.link)
+        else:
+            # XXX count
+            return
+
+        s3path = DOWNLOADS_PREFIX + str(dlid)
+
+        # vid = pick_version(dlid, s3path, rss.fetch_date)
+        vid = None
+        if vid:
+            extras = {"VersionId": vid}
+        else:
+            extras = None
+
+        with io.BytesIO() as bio:
+            # XXX inside try??
+            self.bucket.download_fileobj(s3path, bio, ExtraArgs=extras)
+
+            # XXX inside try? quarantine on error?
+            html = gzip.decompress(bio.getbuffer())
+
+        # legacy system as running in 2023 only saved utf-8 to S3?
+        # may need to auto-detect older files???
+        encoding = "utf-8"
+
+        hmd = story.http_metadata()
+
+        logger.info("%d %s: %d bytes", dlid, hmd.final_url, len(html))
+        # XXX check length, count & discard if too long
+
+        with hmd:
+            hmd.encoding = encoding
+
+        with story.raw_html() as raw:
+            raw.encoding = encoding
+            raw.html = html
+
+        # XXX counter?
+        sender.send_story(story)
 
 
 if __name__ == "__main__":

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -83,8 +83,8 @@ class HistFetcher(StoryProducer):
         # expect local file for now
         with open(self.args.csv) as f:
             for row in csv.DictReader(f):
-                print(row)
                 # typ columns: collect_date,stories_id,media_id,downloads_id,feeds_id,[language,]url
+                logger.info("%r", row)
 
                 url = row.get("url", None)
                 if not url:

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -1,0 +1,149 @@
+"""
+Read CSV of articles from legacy system, using HTML stored
+on Amazon S3, indexed by downloads_id, and queue for processing
+
+TODO?
+Toss stories w/ domain name ending in member of NON_NEWS_DOMAINS
+Take s3 URL for input file
+Drop empty FILENAME.done turn on S3 for completed files?
+Take s3 URL for file w/ list of input files??
+"""
+
+import argparse
+import csv
+import gzip
+import io
+import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple, TypedDict
+
+import boto3
+from mcmetadata.urls import NON_NEWS_DOMAINS
+
+from indexer.story import BaseStory, StoryFactory
+from indexer.worker import StoryProducer, run
+
+logger = logging.getLogger(__name__)
+
+Story = StoryFactory()
+
+# NOTE! Two database epochs (B & D) have overlapping download ids:
+# DB B: 2021-09-15 00:00:00.921164 thru 2021-11-11 00:02:17.402188?
+# DB D: 2021-12-26 10:48:42.490858 thru 2022-01-25 00:00:00.072873?
+
+# db-b/stories_2021_09_15.csv:
+# 2021-09-15 16:36:53.505277,2043951575,18710,3211617068,59843,https://www.businessinsider.com/eff-google-daily-stormer-2017-8#comments
+
+# attrs from boto (not necessarily story downloads):
+# downloads/3211617604 sbRmtvTcbmDH.dxWNcIBsmRz.ffbbosG 18620 2021-09-15T20:51:01
+# downloads/3211617605 dSQTc9dyyVj34GP7zMI0GfOFmEkaQE_K 13761 2021-09-15T20:50:59
+# downloads/3211617605 fKUnm9Sbr8Gt33FaY0gUoKxaq5J3kY1l 36 2021-12-27T05:11:47
+# ....
+# downloads/3257240456 N5Bn9xkkeGgXI1BSSzl71hRi9eiHCMo8 5499 2021-10-16T08:53:20
+# downloads/3257240456 Vp_Qfu7Yo1QkZqWA4RRYu83h0PFoFLOz 8853 2022-01-25T15:47:27
+# downloads/3257240457 N4tYO8GEnt6_px8SHE9VYc5B5N9Yp_hN 36 2021-10-16T08:53:19
+
+OVERLAP_START = 3211617605  # lowest dl_id w/ multiple versions?
+OVERLAP_END = 3257240456  # hightest dl_lid w/ multiple versions?
+
+DB_B_END = "2021-11-12"  # latest possible data in DB B
+DB_D_START = "2021-12-26"  # earliest possible date in DB D
+
+DOWNLOADS_BUCKET = "mediacloud-downloads-backup"
+DOWNLOADS_PREFIX = "downloads/"
+
+# XXX get this from common config?
+MAX_HTML_SIZE = 10000000  # 10MB
+
+
+class HistFetcher(StoryProducer):
+    AUTO_CONNECT: bool = False
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+        ap.add_argument("csv", help="CSV file of stories")
+        ap.add_argument(
+            "--count", type=int, default=4294967296, help="count of stories to queue"
+        )
+
+    def main_loop(self) -> None:
+        assert self.args
+
+        count = self.args.count
+
+        # XXX take keys from environment
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(DOWNLOADS_BUCKET)
+
+        self.qconnect()
+        sender = self.story_sender()
+        self.start_pika_thread()
+
+        # expect local file for now
+        with open(self.args.csv) as f:
+            for row in csv.DictReader(f):
+                print(row)
+                # typ columns: collect_date,stories_id,media_id,downloads_id,feeds_id,[language,]url
+
+                url = row.get("url", None)
+                if not url:
+                    logger.error("no url: %r", row)
+                    # XXX counter?
+                    continue
+
+                try:
+                    dlid = int(row.get("downloads_id") or "")
+                except (KeyError, ValueError):
+                    logger.error("bad downloads_id: %r", row)
+                    # XXX counter?
+                    continue
+
+                if dlid >= OVERLAP_START and dlid <= OVERLAP_END:
+                    logger.error("download id %d in overlap region", dlid)
+                    # XXX need to retrieve available versions and pick!!
+                    continue
+
+                # 2023 era legacy system always wrote UTF-8?
+                # need to revisit for older archives!!!!
+                # XXX test if S3 data decodes w/o errors!!!!!
+                encoding = "utf-8"
+
+                story = Story()
+                with story.rss_entry() as rss:
+                    rss.link = url  # only used for logging
+
+                with story.http_metadata() as hmd:
+                    hmd.final_url = url
+
+                with io.BytesIO() as bio:
+                    s3path = DOWNLOADS_PREFIX + str(dlid)
+                    bucket.download_fileobj(s3path, bio)
+                    html = gzip.decompress(bio.getbuffer())
+
+                logger.info("%s: %d bytes", url, len(html))
+                # XXX check length
+                with story.raw_html() as raw:
+                    raw.encoding = encoding
+                    raw.html = html
+
+                lang = row.get("language", None)
+                if lang:
+                    with story.content_metadata() as cmd:
+                        cmd.language = cmd.full_language = lang
+
+                sender.send_story(story)
+                # counter?
+
+                count -= 1
+                if count <= 0:
+                    logger.info("reached max count")
+                    break
+
+
+if __name__ == "__main__":
+    run(
+        HistFetcher,
+        "hist-fetcher",
+        "Read CSV of historical stories, fetches HTML from S3 and queues",
+    )

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -5,17 +5,14 @@ hist-fetcher (S3 fetch latency is too high for a single process to
 achieve S3 request rate limit (5500 requests/second per prefix)
 """
 
-import argparse
 import csv
 import io
 import logging
-import os
-import sys
 from typing import BinaryIO
 
 from indexer.app import run
 from indexer.queuer import Queuer
-from indexer.story import BaseStory, StoryFactory
+from indexer.story import StoryFactory
 
 logger = logging.getLogger(__name__)
 

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -1,0 +1,108 @@
+"""
+Read CSV of articles from legacy system, make queue entry for hist-fetcher
+(S3 fetch latency is high enough to prevent reading from S3 at full rate)
+
+TODO?
+XXX monitor queue length, and sleep between CSV files?
+Toss stories w/ domain name ending in member of NON_NEWS_DOMAINS
+Take s3 URL for input csv file
+Take s3 URL for bucket to read csv files from
+Drop empty FILENAME.done turd on S3 for completed files?
+"""
+
+import argparse
+import csv
+import io
+import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+from mcmetadata.urls import NON_NEWS_DOMAINS
+
+from indexer.story import BaseStory, StoryFactory
+from indexer.worker import StoryProducer, StorySender, run
+
+logger = logging.getLogger(__name__)
+
+Story = StoryFactory()
+
+
+class HistQueuer(StoryProducer):
+    AUTO_CONNECT: bool = False
+
+    def __init__(self, process_name: str, descr: str):
+        super().__init__(process_name, descr)
+        self.count = 0
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+        ap.add_argument("csvs", help="CSV files of stories", nargs="+")
+        ap.add_argument(
+            "--count", type=int, default=4294967296, help="count of stories to queue"
+        )
+
+    def main_loop(self) -> None:
+        assert self.args
+
+        self.qconnect()
+        sender = self.story_sender()
+        self.start_pika_thread()
+
+        self.count = self.args.count
+        for csv_fname in self.args.csvs:
+            # XXX handle S3 URL for CSV or whole bucket of CSVs
+            # XXX check for s3://....csv.done turd first!!
+            with open(csv_fname) as f:
+                if not self.process_csv(f, sender):
+                    break
+            # XXX if S3, drop PATH.done turd file?
+
+    def process_csv(self, f: io.TextIOBase, sender: StorySender) -> bool:
+        for row in csv.DictReader(f):
+            # typ columns: collect_date,stories_id,media_id,downloads_id,feeds_id,[language,]url
+            logger.info("%r", row)
+
+            url = row.get("url", None)
+            if not url:
+                logger.error("no url: %r", row)
+                # XXX counter?
+                continue
+
+            dlid = row.get("downloads_id", None)
+            if not dlid:
+                logger.error("bad downloads_id: %r", row)
+                # XXX counter?
+                continue
+
+            collect_date = row.get("collect_date", None)
+
+            story = Story()
+            with story.rss_entry() as rss:
+                rss.link = dlid
+                rss.fetch_date = collect_date
+
+            with story.http_metadata() as hmd:
+                hmd.final_url = url
+
+            lang = row.get("language", None)
+            if lang:
+                with story.content_metadata() as cmd:
+                    cmd.language = cmd.full_language = lang
+
+            # XXX counter?
+            sender.send_story(story)
+
+            self.count -= 1
+            if self.count <= 0:
+                logger.info("reached max count")
+                return False
+        return True
+
+
+if __name__ == "__main__":
+    run(
+        HistQueuer,
+        "hist-queuer",
+        "Read CSV of historical stories, queue to hist-fetcher",
+    )

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -1,13 +1,9 @@
 """
-Read CSV of articles from legacy system, make queue entry for hist-fetcher
-(S3 fetch latency is high enough to prevent reading from S3 at full rate)
+Read CSV of articles from legacy system, make queue entry for
+hist-fetcher (S3 fetch latency is high enough to prevent reading from
+S3 at full rate with a single fetcher)
 
-TODO?
-XXX monitor queue length, and sleep between CSV files?
-Toss stories w/ domain name ending in member of NON_NEWS_DOMAINS
-Take s3 URL for input csv file
-Take s3 URL for bucket to read csv files from
-Drop empty FILENAME.done turd on S3 for completed files?
+XXX Toss stories w/ domain name ending in member of NON_NEWS_DOMAINS
 """
 
 import argparse
@@ -16,71 +12,48 @@ import io
 import logging
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import IO, cast
 
 from mcmetadata.urls import NON_NEWS_DOMAINS
 
+from indexer.app import run
+from indexer.queuer import Queuer
 from indexer.story import BaseStory, StoryFactory
-from indexer.worker import StoryProducer, StorySender, run
 
 logger = logging.getLogger(__name__)
 
 Story = StoryFactory()
 
 
-class HistQueuer(StoryProducer):
-    AUTO_CONNECT: bool = False
-
-    def __init__(self, process_name: str, descr: str):
-        super().__init__(process_name, descr)
-        self.count = 0
-
-    def define_options(self, ap: argparse.ArgumentParser) -> None:
-        super().define_options(ap)
-        ap.add_argument("csvs", help="CSV files of stories", nargs="+")
-        ap.add_argument(
-            "--count", type=int, default=4294967296, help="count of stories to queue"
-        )
-
-    def main_loop(self) -> None:
-        assert self.args
-
-        self.qconnect()
-        sender = self.story_sender()
-        self.start_pika_thread()
-
-        self.count = self.args.count
-        for csv_fname in self.args.csvs:
-            # XXX handle S3 URL for CSV or whole bucket of CSVs
-            # XXX check for s3://....csv.done turd first!!
-            with open(csv_fname) as f:
-                if not self.process_csv(f, sender):
-                    break
-            # XXX if S3, drop PATH.done turd file?
-
-    def process_csv(self, f: io.TextIOBase, sender: StorySender) -> bool:
-        for row in csv.DictReader(f):
-            # typ columns: collect_date,stories_id,media_id,downloads_id,feeds_id,[language,]url
-            logger.info("%r", row)
+class HistQueuer(Queuer):
+    def process_file(self, fname: str, fobj: io.IOBase) -> None:
+        # typical columns:
+        # collect_date,stories_id,media_id,downloads_id,feeds_id,[language,]url
+        fobj2 = cast(IO[bytes], fobj)
+        for row in csv.DictReader(io.TextIOWrapper(fobj2)):
+            logger.debug("%r", row)
 
             url = row.get("url", None)
             if not url:
                 logger.error("no url: %r", row)
-                # XXX counter?
+                self.incr_stories("no-url")
                 continue
 
+            # XXX extract FQDN, check if in non-news domain
+
             dlid = row.get("downloads_id", None)
-            if not dlid:
+            if not dlid or not dlid.isdigit():
                 logger.error("bad downloads_id: %r", row)
-                # XXX counter?
+                self.incr_stories("bad-dlid")
                 continue
 
             collect_date = row.get("collect_date", None)
 
             story = Story()
             with story.rss_entry() as rss:
-                rss.link = dlid
-                rss.fetch_date = collect_date
+                rss.link = dlid  # could pass S3 url
+                if collect_date:
+                    rss.fetch_date = collect_date
 
             with story.http_metadata() as hmd:
                 hmd.final_url = url
@@ -90,14 +63,7 @@ class HistQueuer(StoryProducer):
                 with story.content_metadata() as cmd:
                     cmd.language = cmd.full_language = lang
 
-            # XXX counter?
-            sender.send_story(story)
-
-            self.count -= 1
-            if self.count <= 0:
-                logger.info("reached max count")
-                return False
-        return True
+            self.send_story(story)  # increments counter
 
 
 if __name__ == "__main__":

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -13,9 +13,11 @@ from elastic_transport import ObjectApiResponse
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ConflictError, RequestError
 
+from indexer.app import run
 from indexer.elastic import ElasticMixin
 from indexer.story import BaseStory
-from indexer.worker import QuarantineException, StorySender, StoryWorker, run
+from indexer.storyapp import StorySender, StoryWorker
+from indexer.worker import QuarantineException
 
 logger = logging.getLogger(__name__)
 

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -7,10 +7,13 @@ from collections import Counter
 
 # PyPI:
 import mcmetadata
+from bs4.dammit import UnicodeDammit
 
 # local:
+from indexer.app import run
 from indexer.story import BaseStory
-from indexer.worker import QuarantineException, StorySender, StoryWorker, run
+from indexer.storyapp import StorySender, StoryWorker
+from indexer.worker import QuarantineException
 
 QUARANTINE_DECODE_ERROR = True  # discard if False
 
@@ -19,70 +22,116 @@ logger = logging.getLogger("parser")
 
 class Parser(StoryWorker):
     def process_story(self, sender: StorySender, story: BaseStory) -> None:
-        def story_status(status: str) -> None:
-            # one place for label format:
-            self.incr("stories", labels=[("status", status)])
-
         hmd = story.http_metadata()
         final_url = hmd.final_url
         if not final_url:
             rss = story.rss_entry()
             # want notice level!
+            # should NOT have gotten here
             logger.warning("rss link %s final_url %r", rss.link, final_url)
-            story_status("no-url")
+            self.incr_stories("no-url", final_url or "")
             raise QuarantineException("no url")
 
+        # Deal with the character encoding miasma.
+
+        # HTTP Content-Type header can be plain wrong (just a http
+        # server configuration), or bad ("iso-utf-8"), and chardet
+        # makes bad guesses with some frequency, when the HTML <meta>
+        # tag says utf-8.
+
+        # Placing this in RawHtml.unicode and guess_encoding() means
+        # that the routines may want to alter the RawHtml object,
+        # which requires a "with" context, when the caller might have
+        # already entered one, and hides data alteration from the
+        # user.  If it turns out that this needs to be dealt with in
+        # multiple places, reconsider.
+
+        # scrapy uses their own w3lib, which may be more all
+        # encompasing, but it's less easy to use (would require
+        # cribbing code from scrapy). requests has a deprecated
+        # get_encodings_from_content function, which has moved to
+        # requests_toolbelt.utils.deprecated.get_encodings_from_content().
+
+        # Since "historical" HTML (saved on AWS S3 by legacy system)
+        # needs this (doesn't even come with Content-Type info), and
+        # any fetcher using "requests" will need this as well, and
+        # since it's a purely computational bound operation rather
+        # than an I/O bound operation, it seems to belong here, rather
+        # than in multiple fetchers.
+
+        # ALSO: the user-friendly dammit interface seems to be
+        # UnicodeDammit, which returns the decoded string as well as
+        # the encoding, so might as well put the call where we use the
+        # result.
+
         raw = story.raw_html()
+        encoding = raw.encoding or hmd.encoding
+        if encoding:
+            kde = [encoding]
+        else:
+            kde = None
         try:
-            html = raw.unicode
+            raw_html = raw.html or ""
+            ud = UnicodeDammit(raw_html, is_html=True, known_definite_encodings=kde)
         except UnicodeError as e:
             # careful printing exception! may contain entire string!!
             err = type(e).__name__
-            logger.warning("unicode error %s: %s", err, final_url)  # want notice!
-            story_status("no-decode")
+            self.incr_stories("no-decode", final_url)  # want level=NOTICE
             if QUARANTINE_DECODE_ERROR:
                 raise QuarantineException(err)
             else:
                 return
 
+        # XXX also unicode_markup??
+        html = ud.markup  # decoded HTML
+        logger.info("parsing %s: %d characters", final_url, len(html))
         if not html:
-            logger.warning("no HTML: %s", final_url)  # want notice!
-            story_status("no-html")
+            # should NOT have happened!
+            self.incr_stories("no-html", final_url)  # want level=NOTICE
             raise QuarantineException("no html")
 
-        logger.info("parsing %s: %d characters", final_url, len(html))
+        with raw:
+            # Scrapy removes BOM, so do it here too.
+            # this will happen with historical data from S3
+            # and HTML fetched w/ requests.
+            if ud.detector.markup:
+                old_len = len(raw_html)
+                new_len = len(ud.detector.markup)
+                if new_len != old_len:
+                    # maybe log "BOM removed" and give URL?
+                    logger.debug("new len %d, was %d", new_len, old_len)
+                    raw.html = ud.detector.markup
+
+            encoding = ud.original_encoding
+            if encoding and raw.encoding != encoding:
+                logger.debug("encoding %s, was %s", encoding, raw.encoding)
+                raw.encoding = encoding
 
         extract_stats: Counter[str] = Counter()
         try:
             mdd = mcmetadata.extract(final_url, html, stats_accumulator=extract_stats)
         except mcmetadata.exceptions.BadContentError:
-            story_status("too-short")
+            self.incr_stories("too-short", final_url)
             # No quarantine error here, just discard
             return
 
-        # Really slapdash solution for the sake of testing
-        # ^^^^ is this still the case, or is it now "standard operating procedure"??
+        # change datetime object to JSON-safe string
         if mdd["publication_date"] is not None:
             pub_date = mdd["publication_date"].strftime("%Y-%m-%d")
         else:
-            pub_date = "None"
+            pub_date = "None"  # XXX change this to None??? Please!!!
         mdd["publication_date"] = pub_date
 
         method = mdd["text_extraction_method"]
         logger.info("parsed %s with %s date %s", final_url, method, pub_date)
 
         with story.content_metadata() as cmd:
-            # assumes identical item names!!
-            #       could copy items individually with type checking
-            #       if mcmetadata returned TypedDict?
-            # NOTE! url and final_url are only different if
-            # mcmetadata.extract() does the fetch
             for key, val in mdd.items():
-                if hasattr(cmd, key):  # avoid hardwired exceptions list?!
+                if hasattr(cmd, key):  # avoid hardwired exceptions
                     setattr(cmd, key, val)
 
         sender.send_story(story)
-        story_status(f"OK-{method}")
+        self.incr_stories(f"OK-{method}", final_url)
 
         skip_items = {"total", "fetch"}  # stackable, no fetch done
         for item, sec in extract_stats.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "boto3-stubs[s3] ~= 1.34.13",
   "mypy ~= 1.5.1",
   "jinja2-cli ~= 0.8.2",
   "pre-commit ~= 3.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "story-indexer"
 version = "0.0.1"
 dependencies = [
+  "beautifulsoup4 ~= 4.12.2",
   "boto3 ~= 1.28.44",
   "docker ~= 6.1.0",
   "elasticsearch ~= 8.9.0",
@@ -26,6 +27,7 @@ dev = [
   "jinja2-cli ~= 0.8.2",
   "pre-commit ~= 3.4.0",
   "pytest ~= 7.4.2",
+  "types-beautifulsoup4 ~= 4.12.0.20240106",
   "types-pika ~= 1.2.0b1",
   "types-requests ~=2.31.0.2",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --extra=dev --output-file=requirements-dev.txt --strip-extras pyproject.toml
 #
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   automat
     #   service-identity
@@ -21,14 +21,21 @@ boilerpy3==1.0.7
     # via mediacloud-metadata
 boto3==1.28.85
     # via story-indexer (pyproject.toml)
+boto3-stubs==1.34.13
+    # via
+    #   boto3-stubs
+    #   story-indexer (pyproject.toml)
 botocore==1.31.85
     # via
     #   boto3
     #   s3transfer
+botocore-stubs==1.34.13
+    # via boto3-stubs
 certifi==2023.11.17
     # via
     #   elastic-transport
     #   requests
+    #   sentry-sdk
     #   trafilatura
 cffi==1.16.0
     # via cryptography
@@ -63,11 +70,11 @@ dateparser==1.2.0
     # via
     #   htmldate
     #   mediacloud-metadata
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 docker==6.1.3
     # via story-indexer (pyproject.toml)
-elastic-transport==8.10.0
+elastic-transport==8.11.0
     # via elasticsearch
 elasticsearch==8.9.0
     # via story-indexer (pyproject.toml)
@@ -77,7 +84,7 @@ faust-cchardet==2.1.19
     # via mediacloud-metadata
 feedfinder2==0.0.4
     # via newspaper3k
-feedparser==6.0.10
+feedparser==6.0.11
     # via newspaper3k
 filelock==3.13.1
     # via
@@ -85,15 +92,15 @@ filelock==3.13.1
     #   virtualenv
 furl==2.1.3
     # via mediacloud-metadata
-goose3==3.1.17
+goose3==3.1.18
     # via mediacloud-metadata
-htmldate==1.6.0
+htmldate==1.6.1
     # via
     #   mediacloud-metadata
     #   trafilatura
 hyperlink==21.0.0
     # via twisted
-identify==2.5.32
+identify==2.5.33
     # via pre-commit
 idna==3.6
     # via
@@ -130,7 +137,7 @@ langcodes==3.3.0
     # via courlan
 langdetect==1.0.9
     # via goose3
-lxml==4.9.3
+lxml==4.9.4
     # via
     #   goose3
     #   htmldate
@@ -146,6 +153,8 @@ mediacloud-metadata==0.10.0
     # via story-indexer (pyproject.toml)
 mypy==1.5.1
     # via story-indexer (pyproject.toml)
+mypy-boto3-s3==1.34.0
+    # via boto3-stubs
 mypy-extensions==1.0.0
     # via mypy
 newspaper3k==0.2.8
@@ -154,7 +163,7 @@ nltk==3.8.1
     # via newspaper3k
 nodeenv==1.8.0
     # via pre-commit
-numpy==1.26.2
+numpy==1.26.3
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
@@ -170,7 +179,7 @@ parsel==1.8.1
     #   scrapy
 pika==1.3.2
     # via story-indexer (pyproject.toml)
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   goose3
     #   newspaper3k
@@ -198,7 +207,7 @@ pydispatcher==2.0.7
     # via scrapy
 pyopenssl==23.3.0
     # via scrapy
-pytest==7.4.3
+pytest==7.4.4
     # via story-indexer (pyproject.toml)
 python-dateutil==2.8.2
     # via
@@ -219,7 +228,7 @@ rabbitmq-admin==0.2
     # via story-indexer (pyproject.toml)
 readability-lxml==0.8.1
     # via mediacloud-metadata
-regex==2023.10.3
+regex==2023.12.25
     # via
     #   dateparser
     #   nltk
@@ -238,6 +247,8 @@ requests-file==1.5.1
 s3transfer==0.7.0
     # via boto3
 scrapy==2.10.1
+    # via story-indexer (pyproject.toml)
+sentry-sdk==1.34.0
     # via story-indexer (pyproject.toml)
 service-identity==23.1.0
     # via scrapy
@@ -284,13 +295,19 @@ trafilatura==1.6.3
     # via mediacloud-metadata
 twisted==22.10.0
     # via scrapy
+types-awscrt==0.20.0
+    # via botocore-stubs
 types-pika==1.2.0b1
     # via story-indexer (pyproject.toml)
-types-requests==2.31.0.10
+types-requests==2.31.0.20231231
     # via story-indexer (pyproject.toml)
-typing-extensions==4.8.0
+types-s3transfer==0.10.0
+    # via boto3-stubs
+typing-extensions==4.9.0
     # via
+    #   boto3-stubs
     #   mypy
+    #   mypy-boto3-s3
     #   twisted
 tzlocal==5.2
     # via dateparser
@@ -304,6 +321,7 @@ urllib3==2.0.7
     #   elastic-transport
     #   htmldate
     #   requests
+    #   sentry-sdk
     #   trafilatura
     #   types-requests
 virtualenv==20.25.0
@@ -323,7 +341,7 @@ zope-interface==6.1
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.0.2
+setuptools==69.0.3
     # via
     #   nodeenv
     #   scrapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --strip-extras pyproject.toml
 #
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   automat
     #   service-identity
@@ -64,7 +64,7 @@ dateparser==1.2.0
     #   mediacloud-metadata
 docker==6.1.3
     # via story-indexer (pyproject.toml)
-elastic-transport==8.10.0
+elastic-transport==8.11.0
     # via elasticsearch
 elasticsearch==8.9.0
     # via story-indexer (pyproject.toml)
@@ -72,15 +72,15 @@ faust-cchardet==2.1.19
     # via mediacloud-metadata
 feedfinder2==0.0.4
     # via newspaper3k
-feedparser==6.0.10
+feedparser==6.0.11
     # via newspaper3k
 filelock==3.13.1
     # via tldextract
 furl==2.1.3
     # via mediacloud-metadata
-goose3==3.1.17
+goose3==3.1.18
     # via mediacloud-metadata
-htmldate==1.6.0
+htmldate==1.6.1
     # via
     #   mediacloud-metadata
     #   trafilatura
@@ -115,7 +115,7 @@ langcodes==3.3.0
     # via courlan
 langdetect==1.0.9
     # via goose3
-lxml==4.9.3
+lxml==4.9.4
     # via
     #   goose3
     #   htmldate
@@ -131,7 +131,7 @@ newspaper3k==0.2.8
     # via mediacloud-metadata
 nltk==3.8.1
     # via newspaper3k
-numpy==1.26.2
+numpy==1.26.3
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
@@ -146,7 +146,7 @@ parsel==1.8.1
     #   scrapy
 pika==1.3.2
     # via story-indexer (pyproject.toml)
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   goose3
     #   newspaper3k
@@ -185,7 +185,7 @@ rabbitmq-admin==0.2
     # via story-indexer (pyproject.toml)
 readability-lxml==0.8.1
     # via mediacloud-metadata
-regex==2023.10.3
+regex==2023.12.25
     # via
     #   dateparser
     #   nltk
@@ -248,7 +248,7 @@ trafilatura==1.6.3
     # via mediacloud-metadata
 twisted==22.10.0
     # via scrapy
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via twisted
 tzlocal==5.2
     # via dateparser
@@ -279,7 +279,7 @@ zope-interface==6.1
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.0.2
+setuptools==69.0.3
     # via
     #   scrapy
     #   supervisor

--- a/stubs/warcio/archiveiterator.pyi
+++ b/stubs/warcio/archiveiterator.pyi
@@ -1,0 +1,11 @@
+# from https://skeptric.com/python-type-stubs/index.html
+
+import io
+from typing import BinaryIO, Generator
+
+from warcio.recordloader import ArcWarcRecord
+
+class ArchiveIterator:
+    def __init__(self, stream: BinaryIO): ...
+    def __iter__(self) -> Generator[ArcWarcRecord, None, None]: ...
+    def __next__(self) -> ArcWarcRecord: ...

--- a/stubs/warcio/recordloader.pyi
+++ b/stubs/warcio/recordloader.pyi
@@ -1,0 +1,5 @@
+from typing import BinaryIO
+
+class ArcWarcRecord:
+    rec_type: str
+    raw_stream: BinaryIO


### PR DESCRIPTION
Summary of changes by file:
```
new: bin/run-arch-queuer.sh: runs indexer/workers/arch-queuer.py
new: bin/run-hist-queuer.sh: runs indexer/workers/hist-queuer.py
new: bin/run-hist-fetcher.sh: runs indexer/workers/hist-fetcher.py
new: stubs/warcio/{archiveiterator,recordloader}.pyi
pyproject.toml: add explicit use of beautifulsoup4 & stubs, boto3-stubs
regenerated: requirements[-dev].txt
docker/deploy.sh:
	add -T option for pipeline types: batch-fetcher, historical, archive, queue-fetcher
	add deployment_.... vars for docker-compose comments
	add deployment_id: unique id for each deployment
	add xxx_port_exported vars: xxx_port is now INTERNAL port number
	add parser_replicas
docker/dev.sh: add QUEUER_S3_.... var place holders
docker/docker-compose.yml.j2:
	comments to show deployment_... vars
	add DEPLOYMENT_ID worker-environment-var
	pass --type {{pipeline_type}} to configure-pipeline
	add if's for pipeline_type / queuers
	use parser_replicas
	pass importer_args to importer
indexer/app.py:
	rename ArgsProtocol to AppProtocol (now includes stats), add process_args
	App: honor PROCESS_NAME for alternate queues
	Add "run" function (from worker.py)
	Test app now logs at different levels
indexer/blobstore/S3.py: quiet a mypy warning (now that boto stubs installed)
indexer/elastic.py: use AppProtocol, use as base class
indexer/pipeline.py:
	take --type argument for different pipeline types
	subclass to MyPipeline, move topology to "lay_pipe" method
	get "run" from indexer.app
	add fast_queue support (for queue-fetcher)
	prefix private classes with _
new: indexer/queuer.py:
	Queuer base class for programs that queue stories (historical, archive, rss)
	Subclass supplies "process_file" method that is passed a BinaryIO stream
	Supports reading:
		local files
		traversing local directory trees
		reading http/https on the fly
		optional gzip file expansion
		reading S3 objects (prefix match)
		uses "Tracker" class to keep track of ingested files
	Checks output queue(s) to see if filling up
	By default processes one file is space available, and quits
	Option to loop, sleeping
indexer/worker.py: moved all Story related classes to new indexer/storyapp.py
	use DEPLOYMENT_ID for Pika configuration semaphore
	remove old semaphores
	add fast_queue_name
	moved --from-quarantine from QApp to QWorker (always takes input)
	removed ptlogger (pika thread logger)
	add msglogger (for tag # debug messages)
	let pika thread process_data_events sleep for a day (was 10 seconds)
	_stop_pika_thread queues "nop" callback to wake Pika thread
	let _process_messages return (for multi-thread apps)
	Worker:
		honor NO_QUARANTINE member for exceptions to discard
		make RETRY_DELAY_MINUTES a class member
	removed all Story related classes to indexer/storyapp.py
indexer/storyapp.py:
	split from indexer/worker.py
	add MAX_HTML_BYTES, non_news_fqdn
	StoryMixin class, with helpers:
		incr_stories method
		check_story_length (calls incr_stories)
		check_story_url (calls incr_stories)
	Use StoryMixin in StoryProducer, StoryWorker
indexer/tracker.py: FileTracker class for recording processed files
	only/current implementations are:
		DummyFileTracker for testing
		LocalFileTracker (base for local file based classes)
		DBMFileTracker: LocalFileTracker using gdbm
indexer/workers/arch-queuer.py:
	Queuer that reads local/S3 WARC files and queues Stories
indexer/workers/archiver.py:
	use indexer.path.DATAROOT
	use indexer.storyapp
indexer/workers/hist-queuer.py:
	queue Stories from historical .csv files (on S3)
indexer/workers/hist-fetcher.py:
	process Stories from hist-queuer, fetching HTML from S3
indexer/workers/importer.py:
	use indexer.app.run, indexer.storyapp
	add --no-output option (no output to archiver)
indexer/workers/parser.py:
	use indexer.app.run, indexer.storyapp, incr_stories
	use BeautifulSoup4's UnicodeDammit for character set detection, BOM removal, decode
	(needed for historical Stories and any stories fetched using requests)
indexer/fetch_worker.py: use indexer.app.run, indexer.storyapp.StoryProducer, incr_stories
indexer/scripts/qutil.py: use indexer.storyapp
indexer/story_archive_writer.py: IO typing cleanup (prefer BinaryIO)
```