### PR TITLE
Add "parsed_date" field to content metadata

### DIFF
--- a/indexer/story.py
+++ b/indexer/story.py
@@ -172,6 +172,14 @@ class ContentMetadata(StoryData):
     is_homepage: Optional[bool] = None
     is_shortened: Optional[bool] = None
 
+    # parsed_date used by importer to populate ES indexed_date, so
+    # that stories reimported from WARC files get same indexed_date.
+    # ISO format datetime (so researchers can query for new articles)
+    # by indexed date.  Formatted string has microseconds, and ES
+    # stores timestamps in millisecond resolution.  When reading old
+    # WARC files, populated from WARC metadata record WARC-Date header.
+    parsed_date: Optional[str] = None
+
 
 CONTENT_METADATA = class_to_member_name(ContentMetadata)
 

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -364,6 +364,13 @@ class StoryArchiveReader:
                 with story.content_metadata() as cmd:
                     for key, value in j["content_metadata"].items():
                         setattr(cmd, key, value)
+                    if not cmd.parsed_date:
+                        # For archives written before "parsed_date" added;
+                        # Use WARC metadata record WARC-Date header.
+                        date = record.rec_headers["WARC-Date"]
+                        if date.endswith("Z"):  # should always be the case
+                            date = date[:-1]  # remove Z
+                        cmd.parsed_date = date
                 with story.raw_html() as rh:
                     rh.html = html
                     rh.encoding = j["http_metadata"]["encoding"]

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -179,8 +179,11 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
                 with story.content_metadata() as cmd:
                     cmd.publication_date = pub_date
 
-            # pass parsed_date (from parser or an archive file) as indexed_date
-            # fall back to UTC now.
+            # Use parsed_date (from parser or an archive file) as indexed_date,
+            # falling back to UTC now (for everything parsed/queued before
+            # update applied to parser). API users use indexed_date to poll for
+            # newly added stories, so a timestamp.  By default, ES stores times
+            # with millisecond granularity.
             data["indexed_date"] = (
                 content_metadata.get("parsed_date") or datetime.utcnow().isoformat()
             )

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -157,7 +157,7 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
                     logger.error(f"Value for key '{key}' is not provided.")
                     continue
 
-            keys_to_skip = ["is_homepage", "is_shortened"]
+            keys_to_skip = ["is_homepage", "is_shortened", "parsed_date"]
 
             data: dict[str, Optional[Union[str, bool]]] = {
                 k: v for k, v in content_metadata.items() if k not in keys_to_skip
@@ -179,6 +179,11 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
                 with story.content_metadata() as cmd:
                     cmd.publication_date = pub_date
 
+            # pass parsed_date (from parser or an archive file) as indexed_date
+            # fall back to UTC now.
+            data["indexed_date"] = (
+                content_metadata.get("parsed_date") or datetime.utcnow().isoformat()
+            )
             response = self.import_story(data)
             if response and self.output_msgs:
                 # pass story along to archiver (unless disabled)

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -2,6 +2,7 @@
 metadata parser pipeline worker
 """
 
+import datetime as dt
 import logging
 from collections import Counter
 
@@ -130,6 +131,8 @@ class Parser(StoryWorker):
             for key, val in mdd.items():
                 if hasattr(cmd, key):  # avoid hardwired exceptions
                     setattr(cmd, key, val)
+
+            cmd.parsed_date = dt.datetime.utcnow().isoformat()
 
         sender.send_story(story)
         self.incr_stories(f"OK-{method}", final_url)

--- a/stubs/warcio/recordloader.pyi
+++ b/stubs/warcio/recordloader.pyi
@@ -1,5 +1,6 @@
-from typing import BinaryIO
+from typing import Any, BinaryIO, Dict
 
 class ArcWarcRecord:
+    rec_headers: Dict[str, Any]
     rec_type: str
     raw_stream: BinaryIO


### PR DESCRIPTION
New "parsed_date" field allows passing and preserving the date the story was processed, for use as ES "indexed_date".

This is required to queue archived stories and have them put back into the index preserving original date
(API users use "indexed_date" to poll for new stories).

Code might be _slightly_ less complicated if field name was "indexed_date", but that would obscure the actual meaning of the field!