### PR TITLE
result of falling into importer counter rabbit hole.

### DIFF
--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -173,9 +173,5 @@ class TestElasticsearchImporter:
 
     def test_import_story_success(self, importer: ElasticsearchImporter) -> None:
         test_import_data = {**test_data, "url": "http://example_import_story.com"}
-        response = importer.import_story(test_import_data)
-        if response is not None:
-            assert response.get("result") == "created"
-
-        second_response = importer.import_story(test_import_data)
-        assert second_response is None
+        assert importer.import_story(test_import_data)
+        assert not importer.import_story(test_import_data)

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -1,12 +1,12 @@
 """
 elasticsearch import pipeline worker
 """
+
 import argparse
 import logging
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
-from elastic_transport import ObjectApiResponse
 from elasticsearch.exceptions import ConflictError, RequestError
 from mcmetadata.urls import unique_url_hash
 
@@ -16,7 +16,7 @@ from indexer.story import BaseStory
 from indexer.storyapp import StorySender, StoryWorker
 from indexer.worker import QuarantineException
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("importer")
 
 # Index name alias defined in the index_template.json
 INDEX_NAME_ALIAS = "mc_search"
@@ -40,87 +40,141 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
 
         self.output_msgs = self.args.output_msgs
 
+    def incr_pub_date(self, status: str) -> None:
+        """
+        helper for reporting pub_date stats
+        """
+        self.incr("pub_date", labels=[("status", status)])
+
+    # create once, read-only (tuple)
+    # could extract valid keys from index template (schema)??
+    KEYS_TO_SKIP = ("is_homepage", "is_shortened", "parsed_date")
+
     def process_story(self, sender: StorySender, story: BaseStory) -> None:
         """
-        Process story and extract metadataurl
+        Import story into Elasticsearch
         """
-        content_metadata = story.content_metadata().as_dict()
-        if content_metadata:
-            for key, value in content_metadata.items():
-                if value is None or value == "":
-                    logger.warning("Value for key: %s is not provided.", key)
-                    continue
+        content_metadata = story.content_metadata()
+        data: dict[str, Optional[Union[str, bool]]] = {}
 
-            keys_to_skip = ["is_homepage", "is_shortened", "parsed_date"]
+        self.incr("field_check.stories")  # total number of stories checked
+        for key, value in content_metadata.as_dict().items():
+            if key in self.KEYS_TO_SKIP:
+                continue
+            if value is None or value == "":
+                # missing values are not uncommon (publication_date, and sometimes
+                # article_title) so lowering back to info, and counting instead.  NOTE!
+                # NOT using tags, because more than one field may be counted per story,
+                # and a sum of all "missing" fields isn't a count of the number stories
+                # with with a missing field.
+                self.incr(f"field_check.missing.{key}")
+                logger.info("Value for key: %s is not provided.", key)
+                continue
+            assert isinstance(value, (str, bool))  # currently only strs
+            data[key] = value
 
-            data: dict[str, Optional[Union[str, bool]]] = {
-                k: v for k, v in content_metadata.items() if k not in keys_to_skip
-            }
+        # check if empty now, before any tampering (pub_date or indexed_date)
+        if not data:
+            self.incr_stories("no-data", "no-url")
+            raise QuarantineException("no-data")
 
-            # if publication date is None (from parser) or "None"(from archiver), fallback to rss_fetcher pub_date
-            pub_date = data["publication_date"]
-            if pub_date in [None, "None"]:
-                rss_pub_date = story.rss_entry().pub_date
-                if rss_pub_date:
-                    pub_date = datetime.strptime(
-                        rss_pub_date, "%a, %d %b %Y %H:%M:%S %z"
-                    ).strftime("%Y-%m-%d")
-                else:
-                    pub_date = None
+        # if publication date is None (from parser) or "None"(from archiver), fallback to rss_fetcher pub_date
+        pub_date = data.get("publication_date")
+        if pub_date and pub_date != "None":
+            self.incr_pub_date("extracted")  # extracted from content by mcmetadata
+        else:  # None, "", or "None"
+            rss_pub_date = story.rss_entry().pub_date
+            if rss_pub_date:
+                pub_date = datetime.strptime(
+                    rss_pub_date, "%a, %d %b %Y %H:%M:%S %z"
+                ).strftime("%Y-%m-%d")
+                self.incr_pub_date("rss")
+            else:
+                pub_date = None
+                self.incr_pub_date("none")
+            data["publication_date"] = pub_date
 
-                data["publication_date"] = pub_date
+            # PB: NOTE! this means "metadata" will contain data NOT extracted by
+            # mcmetadata, and if it turns out using the RSS date was a bad idea, future
+            # generations reprocessing the archive without reparsing won't know whether
+            # the the metadata publication_date is real (extracted) or not.  If they
+            # REALLY want to know, they can reparse (and may have superior extraction
+            # tools).
+            with content_metadata:
+                content_metadata.publication_date = pub_date
 
-                with story.content_metadata() as cmd:
-                    cmd.publication_date = pub_date
-
-            # Use parsed_date (from parser or an archive file) as indexed_date,
-            # falling back to UTC now (for everything parsed/queued before
-            # update applied to parser). API users use indexed_date to poll for
-            # newly added stories, so a timestamp.  By default, ES stores times
-            # with millisecond granularity.
-            data["indexed_date"] = (
-                content_metadata.get("parsed_date") or datetime.utcnow().isoformat()
-            )
-            response = self.import_story(data)
-            if response and self.output_msgs:
-                # pass story along to archiver (unless disabled)
-                sender.send_story(story)
+        # Use parsed_date (from parser or an archive file) as indexed_date, falling
+        # back to UTC now (for everything parsed/queued before update applied to
+        # parser) if missing or empty/null. API users use indexed_date to poll for
+        # newly added stories, so a timestamp.  ES stores times in milliseconds.
+        data["indexed_date"] = (
+            content_metadata.parsed_date or datetime.utcnow().isoformat()
+        )
+        if self.import_story(data) and self.output_msgs:
+            # pass story along to archiver, unless disabled or duplicate
+            sender.send_story(story)
 
     def import_story(
         self,
         data: dict[str, Optional[Union[str, bool]]],
-    ) -> Optional[ObjectApiResponse[Any]]:
+    ) -> bool:
         """
-        Import a single story to Elasticsearch
+        True if story imported to ES, and should be archived,
+        False if a duplicate,
+        else raises an exception.
         """
-        response = None
-        if data:
-            url_hash = unique_url_hash(str(data.get("url")))
-            # To move to Story index metadata
-            data["indexed_date"] = datetime.utcnow().isoformat()
-            target_index = INDEX_NAME_ALIAS
-            try:
-                response = self.elasticsearch_client().index(
-                    id=url_hash, index=target_index, document=data
-                )
-            except ConflictError:
-                self.incr("stories", labels=[("status", "dups")])
-            except RequestError as e:
-                self.incr("stories", labels=[("status", "reqerr")])
-                raise QuarantineException(repr(e))
-            except Exception:
-                # Capture other exceptions here
-                self.incr("stories", labels=[("status", "failed")])
-                raise
+        # data can never be empty (has been checked, AND "indexed_data" will always be
+        # set, so no check here.
 
-            if response and response.get("result") == "created":
-                logger.info(
-                    f"Story has been successfully imported. to index {target_index}"
-                )
-                import_status_label = "success"
-                self.incr("stories", labels=[("status", import_status_label)])
+        url = data.get("url")  # for testing, hashing, logging
+        if not isinstance(url, str) or url == "":
+            # exceedingly unlikely, but must check to keep
+            # mypy quiet, so might as well do something rather
+            # than pass an empty string, or turn None into "None"
+            self.incr_stories("no-url", "none")
+            raise QuarantineException("no-url")
+        url_hash = unique_url_hash(url)
 
-        return response
+        # NOTE: indexed_date passed in by process_story
+        try:
+            # logs HTTP op with index name and ID str.
+            # create: raises exception if a duplicate.
+            response = self.elasticsearch_client().create(
+                index=INDEX_NAME_ALIAS, id=url_hash, document=data
+            )
+
+            # ES is restful; python library turns HTTP errors into exceptions, and no
+            # exception was thrown, so should only be here if HTTP returned 200.
+            # PARANOIA! create() call always returns ObjectApiResponse.
+            if not response:
+                raise QuarantineException(f"response {response!r}")
+
+            # Always count, and be explicit about what we saw.  Only documented result
+            # values are "created" and "updated". The existing code was only counting
+            # "success" on the expected ("created") result, but returning happy
+            # regardless.  If there is ever an "indexer metadata" sub-object, save id
+            # and response there?!  One could argue that the undesired "updated" result
+            # (that should never be seen) should be returned as False (do not archive).
+            result = response.get("result", "noresult") or "emptyres"
+            self.incr_stories(result, url)  # count, logs result, URL
+            return True
+        except ConflictError:
+            self.incr_stories("dups", url)
+            return False
+        except RequestError as e:
+            # here with over-length content!
+            self.incr_stories("reqerr", url)
+            raise QuarantineException(repr(e))
+        except Exception:
+            # Capture all other exceptions here for counting, and re-raise for retry
+            # (and eventual quarantine if the error is not transient).
+            self.incr_stories("retry", url)
+            raise
+
+        # this should be unreachable (try contains return)
+        # but in the spirit of total paranoia, count, log and quarantine.
+        self.incr_stories("snh", url)
+        raise QuarantineException("should not happen")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the process of checking out odd stats (deleted documents in ES). I ended up falling into a deep rabbit hole.  Tried calling "create" instead of "index".

Many of the changes are paranoia, and are explicit handling (counting, logging, quarantine) of improbable situations.

Using StoryWorker.incr_stories guarantees all stories are logged with status and URL.

If nothing else (and we don't merge this), it's worth reading both versions of the code as an audit.