### PR TITLE
Final(?) tweaks for processing legacy (CSV) stories for 2023

### DIFF
--- a/indexer/story.py
+++ b/indexer/story.py
@@ -109,7 +109,7 @@ class RSSEntry(StoryData):
     title: Optional[str] = None
     domain: Optional[str] = None
     pub_date: Optional[str] = None
-    fetch_date: Optional[str] = None
+    fetch_date: Optional[str] = None  # date from input file name
 
 
 RSS_ENTRY = class_to_member_name(RSSEntry)

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -111,8 +111,8 @@ class RSSEntry(StoryData):
     pub_date: Optional[str] = None
     fetch_date: Optional[str] = None  # date from input file name
 
-    # none of the following are imported/indexed as of 2/2024.
-    # they're being saved for internal tracing/debugging only.
+    # none of the following are imported/indexed as of 2/2024;
+    # available for internal tracing/debugging only.
     source_url: Optional[str] = None  # source tag url property
     source_feed_id: Optional[int] = None  # source tag mcFeedId property
     source_source_id: Optional[int] = None  # source tag mcFeedId property

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -116,7 +116,10 @@ class RSSEntry(StoryData):
     source_url: Optional[str] = None  # source tag url property
     source_feed_id: Optional[int] = None  # source tag mcFeedId property
     source_source_id: Optional[int] = None  # source tag mcFeedId property
-    file_name: Optional[str] = None  # name or URL of source file
+    # NOTE! If we ever move to rss-fetcher delivering stories by queue message,
+    # there won't be a "file".  "source_name" might be a better field name,
+    # but could easily be confused as comming from the RSS <source> tag. IDEAS???
+    file_name: Optional[str] = None  # full name or URL of source (RSS or CSV) file
 
 
 RSS_ENTRY = class_to_member_name(RSSEntry)

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -111,6 +111,13 @@ class RSSEntry(StoryData):
     pub_date: Optional[str] = None
     fetch_date: Optional[str] = None  # date from input file name
 
+    # none of the following are imported/indexed as of 2/2024.
+    # they're being saved for internal tracing/debugging only.
+    source_url: Optional[str] = None  # source tag url property
+    source_feed_id: Optional[int] = None  # source tag mcFeedId property
+    source_source_id: Optional[int] = None  # source tag mcFeedId property
+    file_name: Optional[str] = None  # name or URL of source file
+
 
 RSS_ENTRY = class_to_member_name(RSSEntry)
 

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -116,10 +116,7 @@ class RSSEntry(StoryData):
     source_url: Optional[str] = None  # source tag url property
     source_feed_id: Optional[int] = None  # source tag mcFeedId property
     source_source_id: Optional[int] = None  # source tag mcFeedId property
-    # NOTE! If we ever move to rss-fetcher delivering stories by queue message,
-    # there won't be a "file".  "source_name" might be a better field name,
-    # but could easily be confused as comming from the RSS <source> tag. IDEAS???
-    file_name: Optional[str] = None  # full name or URL of source (RSS or CSV) file
+    via: Optional[str] = None  # how entry was obtained (filename, URL, etc)
 
 
 RSS_ENTRY = class_to_member_name(RSSEntry)

--- a/indexer/workers/fetcher/fetch_worker.py
+++ b/indexer/workers/fetcher/fetch_worker.py
@@ -177,7 +177,10 @@ class FetchWorker(StoryProducer):
                 story_rss_entry.domain = rss_entry["domain"]
                 story_rss_entry.pub_date = rss_entry["pub_date"]
                 story_rss_entry.fetch_date = rss_entry["fetch_date"]
-
+                story_rss_entry.source_url = rss_entry["source_url"]
+                story_rss_entry.source_feed_id = rss_entry["source_feed_id"]
+                story_rss_entry.source_source_id = rss_entry["source_source_id"]
+                story_rss_entry.file_name = rss_entry["file_name"]
             self.stories_to_fetch.append(new_story)
 
         self.gauge(

--- a/indexer/workers/fetcher/fetch_worker.py
+++ b/indexer/workers/fetcher/fetch_worker.py
@@ -31,7 +31,8 @@ MAX_FETCHER_MSG_SIZE: int = (
 class FetchWorker(StoryProducer):
     AUTO_CONNECT: bool = False
 
-    fetch_date: str
+    fetch_date: Optional[str]
+    rss_file: Optional[str]
     sample_size: Optional[int]
     num_batches: int
     batch_index: int
@@ -86,23 +87,26 @@ class FetchWorker(StoryProducer):
             help="Number of stories to batch. Default (None) is 'all of them'",
         )
 
+        ap.add_argument("--rss-file", help="name of local RSS file for testing")
+
     def process_args(self) -> None:
         super().process_args()
 
         assert self.args
         logger.info(self.args)
 
+        self.rss_file = self.fetch_date = None
         if self.args.yesterday:
             logger.info("Fetching for yesterday")
             yesterday = datetime.today() - timedelta(days=2)
-            fetch_date = yesterday.strftime("%Y-%m-%d")
+            self.fetch_date = yesterday.strftime("%Y-%m-%d")
+        elif self.args.fetch_date:
+            self.fetch_date = self.args.fetch_date
+        elif self.args.rss_file:
+            self.rss_file = self.args.rss_file
         else:
-            fetch_date = self.args.fetch_date
-            if not fetch_date:
-                logger.fatal("need fetch date")
-                sys.exit(1)
-
-        self.fetch_date = fetch_date
+            logger.fatal("need --fetch-date, --yesterday or --rss-file")
+            sys.exit(1)
 
         num_batches = self.args.num_batches
         if num_batches is None:
@@ -153,8 +157,12 @@ class FetchWorker(StoryProducer):
 
     def main_loop(self) -> None:
         # Fetch and batch rss
-        logger.info(f"Fetching rss batch {self.batch_index} for {self.fetch_date}")
-        all_rss_records = fetch_daily_rss(self.fetch_date, self.sample_size)
+        logger.info(
+            f"Fetching rss batch {self.batch_index} for {self.fetch_date or self.rss_file}"
+        )
+        all_rss_records = fetch_daily_rss(
+            self.fetch_date, self.sample_size, self.rss_file
+        )
         batches, batch_map = batch_rss(all_rss_records, num_batches=self.num_batches)
         self.rss_batch = batches[self.batch_index]
 

--- a/indexer/workers/fetcher/fetch_worker.py
+++ b/indexer/workers/fetcher/fetch_worker.py
@@ -188,7 +188,7 @@ class FetchWorker(StoryProducer):
                 story_rss_entry.source_url = rss_entry["source_url"]
                 story_rss_entry.source_feed_id = rss_entry["source_feed_id"]
                 story_rss_entry.source_source_id = rss_entry["source_source_id"]
-                story_rss_entry.file_name = rss_entry["file_name"]
+                story_rss_entry.via = rss_entry["via"]
             self.stories_to_fetch.append(new_story)
 
         self.gauge(

--- a/indexer/workers/fetcher/rss_utils.py
+++ b/indexer/workers/fetcher/rss_utils.py
@@ -54,6 +54,7 @@ def fetch_daily_rss(
     else:
         raise RuntimeError("need fetch_date or rss_file")
 
+    # The mediacloud record is XML, so we just read it in directly and parse out our urls.
     parser = etree.XMLParser(recover=True)
     root = etree.fromstring(data, parser=parser)
 

--- a/indexer/workers/fetcher/rss_utils.py
+++ b/indexer/workers/fetcher/rss_utils.py
@@ -24,7 +24,7 @@ class RSSEntry(TypedDict):
     source_url: Optional[str]  # source tag url property
     source_feed_id: Optional[int]  # source tag mcFeedId property
     source_source_id: Optional[int]  # source tag mcSourceId property
-    file_name: str  # full input file name
+    via: str  # full input file name
 
 
 def fetch_daily_rss(
@@ -98,7 +98,7 @@ def fetch_daily_rss(
             "source_url": src_attr("url"),
             "source_feed_id": src_attr_int("mcFeedId"),
             "source_source_id": src_attr_int("mcSourceId"),
-            "file_name": url,  # source file
+            "via": url,  # source file
         }
         found_items.append(entry)
 

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -123,12 +123,12 @@ class HistFetcher(StoryWorker):
         hmd = story.http_metadata()
 
         dlid_str = rss.link
-        if dlid_str is None:
-            self.incr_stories("bad-dlid", "")
-            return
+        if dlid_str is None or not dlid_str.isdigit():
+            self.incr_stories("bad-dlid", dlid_str or "EMPTY")
+            raise QuarantineException("bad-dlid")
 
         # download id as int for version picker
-        dlid = int(dlid_str)  # pre-validated by hist-queuer.py
+        dlid = int(dlid_str)  # validated above
 
         # format timestamp (CSV file collect_date) for version picker
         dldate = time.strftime("%Y-%m-%d", time.gmtime(hmd.fetch_timestamp))

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -170,6 +170,9 @@ class HistFetcher(StoryWorker):
         with story.raw_html() as raw:
             raw.html = html
 
+        with hmd:
+            hmd.response_code = 200
+
         sender.send_story(story)
         self.incr_stories("success", url)
 

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -46,18 +46,24 @@ class HistQueuer(Queuer):
             logger.debug("%r", row)
 
             url = row.get("url")
+            if not isinstance(url, str):
+                self.incr_stories("bad-url", repr(url))
+                continue
+
             if not self.check_story_url(url):
                 continue  # logged and counted
 
-            dlid = row.get("downloads_id", None)
+            dlid = row.get("downloads_id")
             # let hist-fetcher quarantine if bad
 
+            # convert to int: OK if missing or malformed
             try:
                 feeds_id = int(row["feeds_id"])
             except (KeyError, ValueError):
                 # XXX cannot count w/ incr_stories (only incremented once per story)
                 feeds_id = None
 
+            # convert to int: OK if missing or malformed
             try:
                 media_id = int(row["media_id"])
             except (KeyError, ValueError):
@@ -72,7 +78,7 @@ class HistQueuer(Queuer):
                 rss.fetch_date = fetch_date
                 rss.source_feed_id = feeds_id
                 rss.source_source_id = media_id  # media is legacy name
-                rss.file_name = fname
+                rss.via = fname
 
             collect_date = row.get("collect_date", None)
             with story.http_metadata() as hmd:

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -45,7 +45,7 @@ class HistQueuer(Queuer):
         for row in csv.DictReader(io.TextIOWrapper(fobj)):
             logger.debug("%r", row)
 
-            url = row.get("url", None)
+            url = row.get("url")
             if not self.check_story_url(url):
                 continue  # logged and counted
 

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -45,15 +45,12 @@ class HistQueuer(Queuer):
         for row in csv.DictReader(io.TextIOWrapper(fobj)):
             logger.debug("%r", row)
 
-            url = row.get("url", "")
+            url = row.get("url", None)
             if not self.check_story_url(url):
                 continue  # logged and counted
 
             dlid = row.get("downloads_id", None)
-            if not dlid or not dlid.isdigit():
-                logger.error("bad downloads_id: %r", row)
-                self.incr_stories("bad-dlid", url)
-                continue
+            # let hist-fetcher quarantine if bad
 
             try:
                 feeds_id = int(row["feeds_id"])

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -88,9 +88,9 @@ class Parser(StoryWorker):
         html = ud.markup  # decoded HTML
         logger.info("parsing %s: %d characters", final_url, len(html))
         if not html:
-            # should NOT have happened!
+            # can get here from batch fetcher, or if body was just a BOM
             self.incr_stories("no-html", final_url)  # want level=NOTICE
-            raise QuarantineException("no html")
+            return
 
         with raw:
             # Scrapy removes BOM, so do it here too.


### PR DESCRIPTION
NOTE!  Adds RSSEntry fields to preserve feed/source id data in CSV files.
PLEASE comment on the question at https://github.com/philbudne/story-indexer/blob/hist-update/indexer/story.py#L119 (file_name field)
Fetcher will also accept feed_url, feed_id, source_id from RSS file `<source>` tag.
Added --rss-file option to fetcher, to test parsing new RSS files not yet in production.
Set RSSEntry.fetch_date to the date in the name of the CSV file.
Cleaned up version picking (not needed for 2023) to use date from CSV file column instead of fetch_date.
hist-queuer: let hist-fetcher validate the downloads_id
hist-fetcher: quarantine stories with invalid downloads_id
parser: drop messages with no HTML (count only, no quarantine)

