### PR TITLE
Queue based fetcher

### DIFF
--- a/bin/run-queue-fetcher.sh
+++ b/bin/run-queue-fetcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. bin/func.sh
+
+run_python indexer.workers.fetcher.tqfetcher "$@"

--- a/bin/run-rss-queuer.sh
+++ b/bin/run-rss-queuer.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. bin/func.sh
+
+run_python indexer.workers.fetcher.rss-queuer "$@"

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -239,7 +239,15 @@ archive)
 queue-fetcher)
     PIPE_TYPE_PFX=''
     PIPE_TYPE_PORT_BIAS=0	# native ports
-    QUEUER_FILES='--days 7'	# check last seven days
+    # NOTE! If/when queue-fetcher is first used, --yesterdays (--days 1) will
+    # almost certainly queue the day AFTER the day processed by the most recent
+    # batch fetcher (which runs at midnight, before the rss-fetcher has written
+    # the day that just ended, so it always fetches the date for 48 hours ago).
+    # Using --days 2 will fetch both days (the older day first).  After N days,
+    # this can be switched to "--days N" so that if a day (or more) has been
+    # missed due to downtime, any holes will be filled on restart.  The code
+    # that remembers what has been queued is indexer.tracker.
+    QUEUER_FILES='--days 2'	# check last two days
     QUEUER_TYPE='rss-queuer'	# name of run- script
     ;;
 *)

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -74,6 +74,15 @@ class QuarantineException(AppException):
     """
 
 
+class RequeueException(AppException):
+    """
+    Exception for Worker code to requeue message (preserving headers)
+    for QUICK reprocessing.
+
+    Requires ...-fast queue to exist
+    """
+
+
 class InputMessage(NamedTuple):
     """
     would prefer _channel, but not allowed for NamedTuple,
@@ -200,10 +209,14 @@ class QApp(App):
         self._pika_thread: Optional[threading.Thread] = None
         self._running = True
 
+        # debugging aid to use with --from-quarantine:
+        self._crash_on_exception = os.environ.get("WORKER_EXCEPTION_CRASH", "") != ""
+
         # queues/exchanges created using indexer.pipeline:
         self.input_queue_name = input_queue_name(self.process_name)
         self.output_exchange_name = output_exchange_name(self.process_name)
         self.delay_queue_name = delay_queue_name(self.process_name)
+        self.fast_queue_name = fast_queue_name(self.process_name)
 
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
@@ -467,7 +480,7 @@ class QApp(App):
         properties.delivery_mode = PERSISTENT_DELIVERY_MODE
 
         def sender() -> None:
-            logger.debug(
+            msglogger.debug(
                 "send exch '%s' key '%s' %d bytes", exchange, routing_key, len(data)
             )
             chan.basic_publish(exchange, routing_key, data, properties)
@@ -513,7 +526,7 @@ class Worker(QApp):
 
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
-        self._message_queue: queue.Queue[InputMessage] = queue.Queue()
+        self._message_queue: queue.Queue[Optional[InputMessage]] = queue.Queue()
 
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
@@ -535,7 +548,6 @@ class Worker(QApp):
         basic main_loop for a consumer.
         override for a producer!
         """
-
         self._process_messages()
         sys.exit(1)
 
@@ -589,6 +601,8 @@ class Worker(QApp):
 
         while self._running:
             im = self._message_queue.get()  # blocking
+            if im is None:  # kiss of death?
+                break
             self._process_one_message(im)
             self._ack_and_commit(im)
         logger.info("_process_messages returning")
@@ -609,7 +623,12 @@ class Worker(QApp):
         except QuarantineException as e:
             status = "error"
             self._quarantine(im, e)
+        except RequeueException as e:
+            status = "requeue"
+            self._requeue(im, e)
         except Exception as e:
+            if self._crash_on_exception:
+                raise  # for debug
             if self._retry(im, e):
                 status = "retry"
             else:
@@ -751,6 +770,32 @@ class Worker(QApp):
             props,
         )
         return True  # queued for retry
+
+    def set_requeue_delay_ms(self, ms: int) -> None:
+        self.requeue_delay_str = str(int(ms))
+
+    def _requeue(self, im: InputMessage, e: Exception) -> bool:
+        """
+        Requeue message to -fast queue, which has no consumers, with
+        an expiration/TTL; when messages expire, they are routed
+        back to the -in queue via dead-letter-{exchange,routing-key}.
+
+        NOTE! requires -fast queue to be created (fast=True in pipeline.py)
+        preserves all headers (does not zero retry count).
+
+        Does NOT count number of times requeued!
+        """
+        props = BasicProperties(
+            headers=im.properties.headers, expiration=self.requeue_delay_str
+        )
+        self._send_message(
+            im.channel,
+            im.body,
+            DEFAULT_EXCHANGE,
+            self.fast_queue_name,
+            props,
+        )
+        return True  # requeued
 
     def process_message(self, im: InputMessage) -> None:
         raise NotImplementedError("Worker.process_message not overridden")

--- a/indexer/workers/fetcher/rss-queuer.py
+++ b/indexer/workers/fetcher/rss-queuer.py
@@ -1,0 +1,197 @@
+"""
+Queuer to read rss-fetcher synthetic RSS file from rss-fetcher
+and queue for a fetcher.
+
+Takes any number local files, http/https/s3 urls
+plus either --yesterday or --days N
+
+Queuer framework handles local files, http/https/s3 URLs,
+transparently un-gzips.
+
+On-the-fly XML parsing using "SAX" parser.
+
+NOTE! --yesterday only valid after 01:00 GMT
+(before that, gets the day before)
+"""
+
+import argparse
+import gzip
+import html
+import io
+import logging
+import sys
+import time
+import xml.sax
+from typing import BinaryIO, Callable, List, Optional
+
+import requests
+
+from indexer.app import App, run
+from indexer.queuer import Queuer
+from indexer.story import BaseStory, StoryFactory
+from indexer.storyapp import StoryProducer, StorySender
+
+S3_URL_BASE = "https://mediacloud-public.s3.amazonaws.com/backup-daily-rss"
+
+Attrs = xml.sax.xmlreader.AttributesImpl
+
+Story = StoryFactory()
+
+logger = logging.getLogger("queue-rss")
+
+
+class RSSHandler(xml.sax.ContentHandler):
+    def __init__(self, app: "RSSQueuer"):
+        self.app = app
+        self.parsed = 0
+        self.in_item = False
+        self.link = ""
+        self.domain = ""
+        self.pub_date = ""
+        self.title = ""
+
+    def startElement(self, name: str, attrs: Attrs) -> None:
+        # error if in_item is True (missing end element?)
+        if name == "item":
+            self.in_item = True
+        self.content: List[str] = []
+
+    def characters(self, content: str) -> None:
+        """
+        text content inside current tag
+        may come in multiple calls,
+        even if/when no intervening element
+        """
+        # save channel.lastBuildDate for fetch date?
+        self.content.append(content)
+
+    def endElement(self, name: str):  # type: ignore[no-untyped-def]
+        if not self.in_item:
+            return
+
+        # here at end of a tag inside an <item>
+
+        # join bits of tag content together:
+        content = "".join(self.content)
+
+        if name == "link":
+            # undo HTML entity escapes:
+            self.link = html.unescape(content).strip()
+        elif name == "domain":
+            self.domain = content.strip()
+        elif name == "pubDate":
+            self.pub_date = content.strip()
+        elif name == "title":
+            self.title = content.strip()
+        elif name == "item":
+            if self.link and self.domain:
+                s = Story()
+                with s.rss_entry() as rss:
+                    rss.link = self.link
+                    rss.domain = self.domain
+                    rss.pub_date = self.pub_date
+                    rss.title = self.title
+                    # also rss.fetch_date
+
+                self.app.send_story(s)
+
+                self.link = self.domain = self.pub_date = self.title = ""
+                self.parsed += 1
+            else:
+                assert self.app.args
+                # don't muddy the water if just a dry-run:
+                if not self.app.args.dry_run:
+                    self.app.incr_stories("bad", self.link)
+                logger.warning(
+                    "incomplete item: link: %s domain: %s", self.link, self.domain
+                )
+            self.in_item = False
+
+
+class RSSQueuer(Queuer):
+    HANDLE_GZIP = True  # transparently handle .gz files
+
+    def __init__(self, process_name: str, descr: str):
+        super().__init__(process_name, descr)
+
+        self.sample_size: Optional[int] = None
+        self.dry_run = False
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+
+        # handle any number of local/http/s3 files on command line,
+        # plus some short-cuts for loading s3 files from the usual place
+
+        # take any number of specific dates
+        ap.add_argument(
+            "--fetch-date",
+            action="extend",
+            nargs="*",
+            help="Date (in YYYY-MM-DD) to fetch",
+        )
+
+        # optional: one of --yesterday or --days N
+        group = ap.add_mutually_exclusive_group()
+        group.add_argument(
+            "--days",
+            type=int,
+            help="number of past days to fetch",
+        )
+        # equivalent to --days=1
+        group.add_argument(
+            "--yesterday",
+            action="store_true",
+            default=False,
+            help="fetch yesterday's RSS file (after 01:00GMT)",
+        )
+
+    def process_args(self) -> None:
+        super().process_args()
+
+        args = self.args
+        assert args
+
+        def add_by_date(date: str) -> None:
+            args.input_files.append(f"{S3_URL_BASE}/mc-{date}.rss.gz")
+
+        def previous(days: int) -> str:
+            """
+            get date of rss-fetcher file from "days" days ago
+            rss-fetcher output usually ready by 00:45 GMT
+            before then, use previous day!!
+            """
+            return time.strftime(
+                "%Y-%m-%d", time.gmtime(time.time() - (days * 24 + 1) * 60 * 60)
+            )
+
+        def add_previous(days: int) -> None:
+            add_by_date(previous(days))
+
+        self.yesterday = previous(1)  # for range check
+
+        if args.fetch_date:  # handle --fetch-date option(s)
+            for date in args.fetch_date:
+                if len(date) != 10 or date > self.yesterday or date < "2022-02-18":
+                    logger.error("bad date %s", date)
+                else:
+                    add_by_date(date)
+
+        if args.yesterday:
+            add_previous(1)
+        elif args.days is not None:
+            # work backwards from yesterday
+            for days in range(1, args.days + 1):
+                add_previous(days)
+
+    def process_file(self, fname: str, fobj: BinaryIO) -> None:
+        """
+        called for each file/url on command line, and those
+        implied by --fetch-date, --days and --yesterday
+        with an uncompressed (binary) byte stream
+        """
+        xml.sax.parse(fobj, RSSHandler(self))
+
+
+if __name__ == "__main__":
+    run(RSSQueuer, "rss-queuer", "parse and queue rss-fetcher RSS entries")

--- a/indexer/workers/fetcher/rss-queuer.py
+++ b/indexer/workers/fetcher/rss-queuer.py
@@ -15,21 +15,15 @@ NOTE! --yesterday only valid after 01:00 GMT
 """
 
 import argparse
-import gzip
 import html
-import io
 import logging
-import sys
 import time
 import xml.sax
-from typing import BinaryIO, Callable, List, Optional
+from typing import BinaryIO, List, Optional
 
-import requests
-
-from indexer.app import App, run
+from indexer.app import run
 from indexer.queuer import Queuer
-from indexer.story import BaseStory, StoryFactory
-from indexer.storyapp import StoryProducer, StorySender
+from indexer.story import StoryFactory
 
 S3_URL_BASE = "https://mediacloud-public.s3.amazonaws.com/backup-daily-rss"
 

--- a/indexer/workers/fetcher/sched.py
+++ b/indexer/workers/fetcher/sched.py
@@ -1,0 +1,437 @@
+"""
+scheduler for threaded/queue fetcher
+
+Scoreboard/issue/retire terminology comes from CPU instruction
+scheduling.
+
+hides details of data structures and locking.
+"""
+
+import logging
+import math
+import random
+import threading
+import time
+from enum import Enum
+from typing import Any, Callable, Dict, List, NamedTuple, NoReturn, Optional, Type
+
+from indexer.app import App
+
+# try issue twice, with small, random sleep in between
+SECOND_TRY = False
+
+# EXPERIMENT: try Scrapy latency test (keep max_per_slot requests
+# active).  This uses max_per_slot divided by average_request_time as
+# the issue interval, and (except when starting up) ignores
+# max_per_slot as hard limit, and always ignores min_seconds.
+# Primary advantage is for busy feeds with low latency.
+SCRAPY_LATENCY = True
+
+# exponential moving average coefficient for avg_seconds.
+# (typ. used by TCP for RTT est)
+# https://en.wikipedia.org/wiki/Exponential_smoothing
+# scrapy uses simple mean (ALPHA = 0.5)
+ALPHA = 0.25
+
+logger = logging.getLogger(__name__)
+
+
+# _could_ try and map Slots by IP address(es), since THAT gets us closer
+# to the point (of not hammering a particular server),
+#
+#   BUT: Would have to deal with:
+#   1. A particular FQDN may map to multiple IP addrs
+#   2. The order of the IP addreses might well change between queries
+#   3. The ENTIRE SET might change if a CDN is involved!
+#   4. Whether or not we're using IPv6 (if not, can ignore IPv6)
+#   5. IP addresses can serve multiple domains
+#   6. But domains in #5 might have disjoint IP addr sets.
+
+
+class LockError(RuntimeError):
+    """
+    base class for locking exceptions
+    """
+
+
+class LockNotHeldError(LockError):
+    """
+    lock was not held, when should be
+    """
+
+
+class LockHeldError(LockError):
+    """
+    lock was held, when should not be
+    """
+
+
+class LockTimeout(LockError):
+    """
+    took too long to get lock
+    """
+
+
+class Lock:
+    """
+    wrapper for threading.Lock
+    keeps track of thread that holds lock
+    """
+
+    def __init__(self, name: str, error_handler: Callable[[], None]):
+        self.name = str
+        self._lock = threading.Lock()
+        self._error_handler = error_handler
+        self._owner: Optional[threading.Thread] = None
+
+    def held(self) -> bool:
+        """
+        return True if current thread already holds lock
+        """
+        return self._owner is threading.current_thread()
+
+    def _raise(self, exc_type: Type[LockError]) -> NoReturn:
+        """
+        here on fatal locking error
+        call error handler and raise exception
+        """
+        self._error_handler()
+        raise exc_type(self.name)
+
+    def assert_held(self) -> None:
+        if not self.held():
+            self._raise(LockNotHeldError)
+
+    def assert_not_held(self) -> None:
+        if self.held():
+            self._raise(LockHeldError)
+
+    def __enter__(self) -> Any:
+        self.assert_not_held()  # non-recursive lock
+        if not self._lock.acquire(timeout=120):
+            self._raise(LockTimeout)
+        self._owner = threading.current_thread()
+
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
+        self._owner = None
+        self._lock.release()
+
+
+_NEVER = 0.0
+
+
+class Timer:
+    """
+    measure intervals; doesn't start ticking until reset called.
+    """
+
+    def __init__(self, duration: Optional[float]) -> None:
+        """
+        lock is container object lock (for asserts)
+        """
+        self.last = _NEVER
+        self.duration = duration
+
+    def elapsed(self) -> float:
+        """
+        return seconds since last "reset"
+        """
+        if self.last == _NEVER:
+            return math.inf
+        return time.monotonic() - self.last
+
+    def reset(self) -> None:
+        """
+        (re)start from zero
+        """
+        self.last = time.monotonic()
+
+    def expired(self) -> bool:
+        return self.duration is not None and self.elapsed() >= self.duration
+
+    def __str__(self) -> str:
+        if self.last == _NEVER:
+            return "not set"
+        if self.expired():
+            return "expired"
+        return f"{self.elapsed():.3f}"
+
+
+class IssueStatus(Enum):
+    """
+    return value from Slot._issue
+    """
+
+    OK = 0  # slot assigned
+    BUSY = 1  # too many fetches active or too soon
+    SKIPPED = 2  # recent connection error
+
+
+class Slot:
+    """
+    A slot for a single id (eg domain) within a ScoreBoard
+    """
+
+    def __init__(self, slot_id: str, sb: "ScoreBoard"):
+        self.slot_id = slot_id  # ie; domain
+        self.sb = sb
+
+        self.active_count = 0
+        self.active_threads: List[str] = []
+        self.last_issue = Timer(sb.min_seconds)
+        # time since last error at this workplace
+        self.last_conn_error = Timer(sb.conn_retry_seconds)
+        self.avg_seconds = 0.0  # smoothed average
+
+        # XXX *COULD* keep list of active threads
+        # (instead of active count)
+
+    def _issue(self) -> IssueStatus:
+        """
+        return True if safe to issue (must call "retire" after)
+        return False if cannot be issued now
+        """
+        self.sb.big_lock.assert_held()
+        if SCRAPY_LATENCY:
+            # scrapy issue interval is avg_latency / concurrency
+            # goal is to keep "concurrency" requests active
+            if self.avg_seconds == 0:
+                if self.active_count >= self.sb.max_per_slot:
+                    return IssueStatus.BUSY
+            else:  # have avg_seconds:
+                elapsed = self.last_issue.elapsed()
+                goal = self.avg_seconds / self.sb.max_per_slot
+                logger.debug("%s: elapsed %.3f goal %.3f", self.slot_id, elapsed, goal)
+                if elapsed < goal:
+                    return IssueStatus.BUSY
+        else:
+            if self.active_count >= self.sb.max_per_slot:
+                return IssueStatus.BUSY
+
+            if not self.last_issue.expired():
+                # issued recently
+                return IssueStatus.BUSY
+
+        # see if connection to domain failed "recently".
+        # last test so that preference is short delay
+        # (and hope an active fetch succeeds).
+        # XXX reconsider this to reduce fast traffic???
+        if not self.last_conn_error.expired():
+            return IssueStatus.SKIPPED
+
+        self.active_count += 1
+        self.last_issue.reset()
+
+        self.active_threads.append(threading.current_thread().name)
+        return IssueStatus.OK
+
+    def retire(self, got_connection: bool, sec: float) -> None:
+        """
+        called when a fetch attempt has ended.
+        got_connection is False when the connection attempt failed.
+        """
+        with self.sb.big_lock:
+            assert self.active_count > 0
+            self.active_count -= 1
+            self.active_threads.remove(threading.current_thread().name)  # O(n)
+            if not got_connection:
+                self.last_conn_error.reset()
+            else:
+                if self.avg_seconds == 0:
+                    self.avg_seconds = sec
+                else:
+                    # exponentially moving average (typ. used by TCP for RTT est)
+                    # https://en.wikipedia.org/wiki/Exponential_smoothing
+                    oavg = self.avg_seconds
+                    self.avg_seconds += (sec - self.avg_seconds) * ALPHA
+                    logger.info(
+                        "%s: sec %.3f old %.3f new %.3f",
+                        self.slot_id,
+                        sec,
+                        oavg,
+                        self.avg_seconds,
+                    )
+
+            # adjust scoreboard counters
+            self.sb._slot_retired(self.active_count == 0)
+
+            # consider removing idle slot if no bans in place
+            self._consider_removing()
+
+    def _consider_removing(self) -> None:
+        self.sb.big_lock.assert_held()  # PARANOIA
+        if (
+            self.active_count == 0
+            and self.last_issue.expired()
+            and self.last_conn_error.expired()
+        ):
+            logger.debug("removing idle slot %s", self.slot_id)
+            self.sb._remove_slot(self.slot_id)
+
+
+# status/value tuple: popular in GoLang
+class IssueReturn(NamedTuple):
+    status: IssueStatus
+    slot: Optional[Slot]  # if status == OK
+
+
+class ThreadStatus:
+    info: Optional[str]  # work info (URL or "idle")
+    ts: float  # time.monotonic
+
+
+class ScoreBoard:
+    """
+    keep score of active requests by "id" (str)
+    """
+
+    def __init__(
+        self,
+        app: App,  # for stats
+        max_active: int,  # total concurrent active limit
+        max_per_slot: int,  # max active with same id (domain)
+        min_seconds: float,  # seconds between issues for slot
+        conn_retry_seconds: float,  # seconds before connect retry
+    ):
+        self.app = app
+        # single lock, rather than one each for scoreboard, active count,
+        # and each slot.  Time spent with lock held should be small,
+        # and lock ordering issues likely to make code complex and fragile!
+
+        self.big_lock = Lock(
+            "big_lock", self.debug_info_nolock
+        )  # covers ALL variables!
+        self.max_active = max_active
+        self.max_per_slot = max_per_slot
+        self.min_seconds = min_seconds
+        self.conn_retry_seconds = conn_retry_seconds
+        self.slots: Dict[str, Slot] = {}  # map "id" (domain) to Slot
+        self.active_fetches = 0
+        self.active_slots = 0
+
+        # map thread name to ThreadStatus
+        self.thread_status: Dict[str, ThreadStatus] = {}
+
+    def _get_slot(self, slot_id: str) -> Slot:
+        # _COULD_ try to use IP addresses to map to slots, BUT would
+        # have to deal with multiple addrs per domain name and
+        # possibility of non-overlapping sets from different fqdns
+        self.big_lock.assert_held()  # PARANOIA
+        slot = self.slots.get(slot_id, None)
+        if not slot:
+            slot = self.slots[slot_id] = Slot(slot_id, self)
+        return slot
+
+    def _remove_slot(self, slot_id: str) -> None:
+        del self.slots[slot_id]
+
+    def _issue(self, slot_id: str, note: str) -> IssueReturn:
+        with self.big_lock:
+            if self.active_fetches < self.max_active:
+                slot = self._get_slot(slot_id)
+                status = slot._issue()
+                if status == IssueStatus.OK:
+                    # *MUST* call slot.retire() when done
+                    if slot.active_count == 1:  # was idle
+                        self.active_slots += 1
+                    self.active_fetches += 1
+                    self._set_thread_status(note)  # full URL
+                    return IssueReturn(status, slot)
+            else:
+                status = IssueStatus.BUSY
+        return IssueReturn(status, None)
+
+    def issue(self, slot_id: str, note: str) -> IssueReturn:
+        ir = self._issue(slot_id, note)
+        if ir.status == IssueStatus.BUSY and SECOND_TRY:
+            # experiment: wait a few seconds and try again,
+            # both to increase liklihood of issue,
+            # and to de-clump the queue:
+            # can't have different intervals in delay queue, so do it here:
+            time.sleep(5.0 * random.random() + 1)
+            ir = self._issue(slot_id, note)
+        return ir
+
+    def _slot_retired(self, idle: bool) -> None:
+        """
+        here from slot.retired()
+        """
+        self.big_lock.assert_held()
+        assert self.active_fetches > 0
+        self.active_fetches -= 1
+        if idle:
+            assert self.active_slots > 0
+            self.active_slots -= 1
+            # XXX _consider_removing
+        self._set_thread_status("idle")
+
+    def _set_thread_status(self, info: str) -> None:
+        """
+        save status for debug info
+        """
+        # no lock assert: only current thread can write it's own status item
+        index = threading.current_thread().name
+        ts = self.thread_status.get(index, None)
+        if not ts:
+            ts = self.thread_status[index] = ThreadStatus()
+        ts.info = info
+        ts.ts = time.monotonic()
+
+    def periodic(self) -> None:
+        """
+        called periodically from main thread
+        """
+        with self.big_lock:
+            # do this less frequently?
+            for slot in list(self.slots.values()):
+                slot._consider_removing()
+
+            recent = len(self.slots)
+            logger.info(
+                "%d recently active; %d URLs in %d domains active",
+                recent,
+                self.active_fetches,
+                self.active_slots,
+            )
+
+            self.app.gauge("active.recent", recent)
+            self.app.gauge("active.fetches", self.active_fetches)
+            self.app.gauge("active.slots", self.active_slots)
+
+    def debug_info_nolock(self) -> None:
+        """
+        NOTE!!! called when lock attempt times out!
+        dumps info without attempting to get lock!
+        """
+        logger.info(
+            "%d slots; %d URLs in %d domains active",
+            len(self.slots),
+            self.active_fetches,
+            self.active_slots,
+        )
+
+        for domain, slot in list(self.slots.items()):
+            logger.info(
+                "%s: %s last issue: %s last err: %s",
+                domain,
+                ",".join(slot.active_threads),
+                slot.last_issue,
+                slot.last_conn_error,
+            )
+
+        # here without lock, so grab before examining:
+        lock_owner_thread = self.big_lock._owner
+        if lock_owner_thread:
+            lock_owner_name = lock_owner_thread.name
+        else:
+            lock_owner_name = "NONE"
+
+        now = time.monotonic()
+        for name, ts in list(self.thread_status.items()):
+            if name == lock_owner_name:
+                have_lock = " *LOCK*"
+            else:
+                have_lock = ""
+            # by definition debug info, but only on request/error
+            # so try to avoid having it filtered out:
+            logger.info("%s%s %.3f %s", name, have_lock, now - ts.ts, ts.info)

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -34,7 +34,6 @@ import signal
 import time
 from types import FrameType
 from typing import NamedTuple, Optional
-from urllib.parse import SplitResult, urlsplit
 
 import requests
 from requests.exceptions import ConnectionError
@@ -47,12 +46,7 @@ from indexer.storyapp import (
     non_news_fqdn,
     url_fqdn,
 )
-from indexer.worker import (
-    CONSUMER_TIMEOUT_SECONDS,
-    DEFAULT_EXCHANGE,
-    QuarantineException,
-    RequeueException,
-)
+from indexer.worker import QuarantineException, RequeueException
 from indexer.workers.fetcher.sched import IssueStatus, ScoreBoard
 
 # internal scheduling:

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -1,0 +1,394 @@
+# XXX handle missing URL schema?
+# XXX Quarantine bad URLs?
+"""
+"Threaded Queue Fetcher" using RabbitMQ
+
+NOTE! As of 2023 with CPython, the Global Interpreter Lock (GIL) means
+that threads don't give greater concurrency than async/coroutines
+(only one thread/task runs at a time), BUT PEP703 describes work in
+progress to eliminate the GIL, over time, enabling the code to run on
+multiple cores.
+
+When a Story can't be fetched because of connect rate or concurrency
+limits, the Story is queued to a "fast delay" queue to avoid book keeping
+complexity (and having an API that allows not ACKing a message immediately).
+
+In theory we have thirty minutes to ACK a message
+before RabbitMQ has a fit (closes connection), so
+holding on to Stories that can't be processed
+immediately is POSSIBLE, *BUT* the current API acks
+the message on return from process_message.
+
+To delay ACK would need:
+1. A way to disable automatic ACK (ie; return False)
+2. Passing the delivery tag (or whole InputMessage - bleh) to process_story
+3. An "ack" method on the StorySender object.
+
+Handling retries (on connection errors) would either require
+re-pickling the Story, or the InputMessage
+"""
+
+import argparse
+import logging
+import signal
+import time
+from types import FrameType
+from typing import NamedTuple, Optional
+from urllib.parse import SplitResult, urlsplit
+
+import requests
+from requests.exceptions import ConnectionError
+
+from indexer.app import run
+from indexer.story import BaseStory
+from indexer.storyapp import (
+    MultiThreadStoryWorker,
+    StorySender,
+    non_news_fqdn,
+    url_fqdn,
+)
+from indexer.worker import (
+    CONSUMER_TIMEOUT_SECONDS,
+    DEFAULT_EXCHANGE,
+    QuarantineException,
+    RequeueException,
+)
+from indexer.workers.fetcher.sched import IssueStatus, ScoreBoard
+
+# internal scheduling:
+SLOT_REQUESTS = 2  # concurrent connections per domain
+DOMAIN_ISSUE_SECONDS = 5.0  # interval between issues for a domain (5s = 12/min)
+
+# time cache server as bad after a connection failure
+CONN_RETRY_MINUTES = 10
+
+# requests timeouts:
+CONNECT_SECONDS = 30.0
+READ_SECONDS = 30.0  # for each read?
+
+# HTTP parameters:
+MAX_REDIRECTS = 30
+
+# get from common place (also used by rss-fetcher)
+USER_AGENT = "mediacloud bot for open academic research (+https://mediacloud.org)"
+
+# scrapy default headers include: "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+HEADERS = {"User-Agent": USER_AGENT}
+
+# HHTP response codes to retry
+# (all others cause URL to be discarded)
+RETRY_HTTP_CODES = set(
+    [
+        408,  # Request Timeout
+        429,  # Too Many Requests
+        500,  # Internal Server Error
+        # 501 is "Not Implemented"
+        502,  # Bad Gateway
+        503,  # Service Unavailable
+        504,  # Gateway Timeout
+        # Cloudflare:
+        522,  # Connection timed out
+        524,  # A Timeout Occurred
+    ]
+)
+
+# distinct counters for these HTTP response codes:
+SEPARATE_COUNTS = set([403, 404, 429])
+
+logger = logging.getLogger("fetcher")  # avoid __main__
+
+
+class Retry(Exception):
+    """
+    Exception to throw for explicit retries
+    """
+
+
+class FetchReturn(NamedTuple):
+    resp: Optional[requests.Response]
+
+    # only valid if resp is None:
+    counter: str
+    quarantine: bool
+
+
+class Fetcher(MultiThreadStoryWorker):
+    WORKER_THREADS_DEFAULT = 200  # equiv to 20 fetchers, with 10 active fetches
+
+    # Just discard stories after connection errors:
+    # NOTE: other requests.exceptions may be needed
+    # but entire RequestException hierarchy includes bad URLs
+    NO_QUARANTINE = (Retry, ConnectionError)
+
+    def __init__(self, process_name: str, descr: str):
+        super().__init__(process_name, descr)
+
+        self.scoreboard: Optional[ScoreBoard] = None
+        self.previous_fragment = ""
+
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+        ap.add_argument(
+            "--issue-interval",
+            "-I",
+            type=int,
+            default=DOMAIN_ISSUE_SECONDS,
+            help=f"domain request interval (default: {DOMAIN_ISSUE_SECONDS})",
+        )
+        ap.add_argument(
+            "--slot-requests",
+            "-S",
+            type=int,
+            default=SLOT_REQUESTS,
+            help=f"requests/domain (default: {SLOT_REQUESTS})",
+        )
+
+    def process_args(self) -> None:
+        super().process_args()
+
+        # Make sure cannot attempt a URL twice
+        # using old status information:
+        assert CONN_RETRY_MINUTES < self.RETRY_DELAY_MINUTES
+
+        assert self.args
+        self.scoreboard = ScoreBoard(
+            self,
+            self.workers,
+            self.args.slot_requests,
+            self.args.issue_interval,
+            CONN_RETRY_MINUTES * 60,
+        )
+
+        # Unless the input RSS entries are well mixed (and this would
+        # not be the case if the rss-fetcher queued RSS entries to us
+        # directly), RSS entries for the same domain will travel in
+        # packs/clumps/trains.  If the "fast" delay is too long, that
+        # allows only one URL to be issued each time the train passes.
+        # So set the "fast" delay JUST long enough so they come back
+        # when intra-request issue interval has passed.
+        self.set_requeue_delay_ms(1000 * self.args.issue_interval)
+
+        # enable debug dump on SIGQUIT (CTRL-\)
+        def quit_handler(sig: int, frame: Optional[FrameType]) -> None:
+            if self.scoreboard:
+                self.scoreboard.debug_info_nolock()
+
+        signal.signal(signal.SIGQUIT, quit_handler)
+
+    def periodic(self) -> None:
+        """
+        called from main_loop
+        """
+        assert self.scoreboard
+        with self.timer("status"):
+            self.scoreboard.periodic()
+
+    def fetch(self, sess: requests.Session, fqdn: str, url: str) -> FetchReturn:
+        """
+        perform HTTP get, tracking redirects looking for non-news domains
+
+        Returns FetchReturn NamedTuple for uniform handling of counts.
+        """
+        redirects = 0
+
+        # loop following redirects
+
+        # prepare initial request:
+        request = requests.Request("GET", url, headers=HEADERS)
+        prepreq = sess.prepare_request(request)
+        while True:
+            with self.timer("get"):  # time each HTTP get
+                try:
+                    resp = sess.send(
+                        prepreq,
+                        allow_redirects=False,
+                        timeout=(CONNECT_SECONDS, READ_SECONDS),
+                        verify=False,  # raises connection rate
+                    )
+                except (
+                    requests.exceptions.InvalidSchema,
+                    requests.exceptions.MissingSchema,
+                    requests.exceptions.InvalidURL,
+                ):
+                    # all other exceptions trigger retries in indexer.Worker
+                    return FetchReturn(None, "badurl2", False)
+
+            if not resp.is_redirect:
+                # here with a non-redirect HTTP response:
+                # it could be an HTTP error!
+
+                # XXX report redirect count as a timing?
+                return FetchReturn(resp, "SNH", False)
+
+            # here with redirect:
+            nextreq = resp.next  # PreparedRequest | None
+            if nextreq:
+                url = prepreq.url or ""
+                prepreq = nextreq
+            else:
+                url = ""
+
+            if not url:
+                return FetchReturn(None, "badredir", False)
+
+            redirects += 1
+            if redirects >= MAX_REDIRECTS:
+                return FetchReturn(None, "maxredir", False)
+
+            try:
+                fqdn = url_fqdn(url)
+            except (TypeError, ValueError):
+                return FetchReturn(None, "badredir2", False)
+
+            # NOTE: adding a counter here would count each story fetch attempt more than once
+
+            logger.info("redirect (%d) => %s", resp.status_code, url)
+            if non_news_fqdn(fqdn):
+                return FetchReturn(None, "non-news2", False)
+
+        # end infinite redirect loop
+
+    def process_story(self, sender: StorySender, story: BaseStory) -> None:
+        """
+        called from multiple worker threads!!
+
+        This routine should call incr_stories EXACTLY once!
+        """
+        rss = story.rss_entry()
+
+        url = rss.link
+        if not url:
+            return self.incr_stories("no-url", repr(url))
+        assert isinstance(url, str)
+        assert self.scoreboard is not None
+
+        # XXX handle missing URL schema??
+
+        # BEFORE issue (discard without any delay)
+        try:
+            fqdn = url_fqdn(url)
+        except (TypeError, ValueError):
+            return self.incr_stories("badurl1", url)
+
+        if non_news_fqdn(fqdn):
+            return self.incr_stories("non-news", url)
+
+        # report time to issue: if this jumps up, it's
+        # likely due to lock contention!
+        with self.timer("issue"):
+            # XXX fqdn isn't QUITE right: it means every
+            # foobar.blogspot.com is treated as a separate server.
+            # Really want to use IP address (see sched.py), but that
+            # would require resolving the FQDN, and *THEN* using that
+            # address to make the HTTP connection *AND* subsequent
+            # redirect fetches (if the FQDN stays the same).
+
+            # NOT using "domain" from RSS file because I originally
+            # was planning to move the "issue" call inside the
+            # redirect loop (getting clearance for each FQDN along the
+            # chain), but if we ended up with a "busy", we'd have to
+            # retry and start ALL over, or add a field to the Story
+            # indicating the "next URL" to attempt to fetch, along
+            # with a count of followed redirects.
+            ir = self.scoreboard.issue(fqdn, url)
+
+        if ir.slot is None:  # could not be issued
+            if ir.status == IssueStatus.SKIPPED:
+                # Skipped due to recent connection error: Treat as if
+                # we saw an error as well (incrementing retry count on the Story)
+                # rather than waiting 30 seconds for connection to fail again.
+                # After a failure the scheduler remembers the slot as failing
+                # for CONN_RETRY_MINUTES (not currently tunable via an option).
+                self.incr_stories("skipped", url)
+                raise Retry("skipped due to recent connection failure")
+            else:
+                # here when "busy", due to one of (in order of likelihood):
+                # 1. per-fqdn connect interval not reached
+                # 2. per-fqdn currency limit reached
+                # 3. total concurrecy limit reached.
+                # requeue in short-delay queue, without counting as retry.
+                self.incr_stories("busy", url, log_level=logging.DEBUG)
+                raise RequeueException("busy")  # does not increment retry count
+
+        # here with slot marked active *MUST* call ir.slot.retire!!!!
+        t0 = time.monotonic()
+        with self.timer("fetch"):
+            # log starting URL
+            logger.info("fetch %s", url)
+
+            sess = requests.Session()
+            try:  # call retire on exit
+                fret = self.fetch(sess, fqdn, url)
+                got_connection = True
+            except Exception:
+                self.incr_stories("noconn", url)
+                got_connection = False
+                raise  # re-raised for retry counting
+            finally:
+                # decrement slot active_count!
+                # remember if connection attempt failed.
+                ir.slot.retire(got_connection, time.monotonic() - t0)
+                sess.close()
+
+        resp = fret.resp  # requests.Response
+        if resp is None:  # NOTE!!! non-200 responses are Falsy?!
+            self.incr_stories(fret.counter, url)
+            if fret.quarantine:
+                raise QuarantineException(fret.counter)
+            return
+
+        status = resp.status_code
+        if status != 200:
+            if status in SEPARATE_COUNTS:
+                counter = f"http-{status}"
+            else:
+                counter = f"http-{status//100}xx"
+
+            msg = f"HTTP {status} {resp.reason}"
+            if status in RETRY_HTTP_CODES:
+                self.incr_stories(counter, url)
+                raise Retry(msg)
+            else:
+                return self.incr_stories(counter, msg)
+
+        # here with status == 200
+        content = resp.content  # bytes
+        lcontent = len(content)
+        ct = resp.headers.get("content-type", "")
+
+        logger.info("length %d content-type %s", lcontent, ct)  # XXX report ms?
+
+        # Scrapy skipped non-text documents: need to filter them out
+        if not resp.encoding and not (
+            ct.startswith("text/")
+            or ct.startswith("application/xhtml")
+            or ct.startswith("application/vnd.wap.xhtml+xml")
+            or ct.startswith("application/xml")
+        ):
+            # other XML types handled by scrapy: application/atom+xml
+            # application/rdf+xml application/rss+xml.
+            # Logging the rejected content-types here
+            # so that they can be seen in the log files:
+            return self.incr_stories("not-text", url)
+
+        if not self.check_story_length(content, url):
+            return  # logged and counted
+
+        final_url = resp.url
+        with self.timer("queue"):
+            with story.http_metadata() as hmd:
+                hmd.response_code = status
+                hmd.final_url = final_url
+                hmd.encoding = resp.encoding  # from content-type header
+                hmd.fetch_timestamp = time.time()
+
+            with story.raw_html() as rh:
+                rh.html = content
+                rh.encoding = resp.encoding
+
+            sender.send_story(story)
+        self.incr_stories("success", final_url)
+
+
+if __name__ == "__main__":
+    run(Fetcher, "fetcher", "HTTP Page Fetcher")


### PR DESCRIPTION
Adds two new files, and some minor infrastructure changes (logging and "fast requeue") to put my crude queue-based fetcher "in tree", and available if/until needed.

The "theory of operation" is that once a story is queued, all state is maintained in the queue, and the fetcher runs continuously servicing the queue.  If there is an outage, the queue will be loaded with all unfetched articles when the system is restarted.

All fetching work is done in threads (can use regular blocking code/libraries): the "scheduler" keeps a single lock on all critical data which is only required:
1. to "issue" (start) a story
2. when the fetch attempt has completed
3. for the main thread, once a minute to do cleanup & reporting.

Stats are reported on every story handled (connection error, HTTP error, etc). If a fetch fails due to a "soft" error (DNS lookup error, connection failed, some HTTP 5xx codes) the story will be retried in an hour up to 12 times (scrapy tries once, at end of run?).

The scheduler keeps track (by fully qualified domain name) of:
1. whether a connection has failed recently, and if so, defers fetching (to avoid repeated 30s timeouts on connect attempts)
2. number of active fetches for the FQDN
3. average latency of successful fetches, and uses that to try to issue enough requests to keep a fixed number active like scrapy does (or, alternatively to limit connection interval and concurrent connections).

If the a dequeued item can't be started ("issued") immediately, it's requeued to the "fetcher-fast" queue, and will reappear (at the end a short delay) at the end of the input queue.  This puts load on RabbitMQ (when the queue contains nothing but URLs for a few larger domains), but avoids hairly/delicate bookkeeping in the fetcher (the current Worker class doesn't allow keeping a message "checked-out" (in the library sense) of the queue, and if it did, workers could only keep an unacknowledged story for 30 minutes before RabbitMQ has a fit (and closes the connection)).

Which fetcher (batch or queue) is used is controlled by deploy.sh (default in PIPELINE_TYPE is "batch-fetcher"; running deploy with `-T queue-fetcher` will deploy a regularly named indexer stack (dev/staging or prod) using the queue based fetcher instead of the batch-fetcher.