### PR TITLE
Limit text_content to Lucene term byte length

### DIFF
--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping, Optional, Union
 import pytest
 from elasticsearch import ConflictError, Elasticsearch
 
-from indexer.workers.importer import ElasticsearchImporter
+from indexer.workers.importer import ElasticsearchImporter, truncate_str
 
 
 @pytest.fixture(scope="class", autouse=True)
@@ -96,6 +96,16 @@ test_data: Mapping[str, Optional[Union[str, bool]]] = {
     "text_content": "Lorem ipsum dolor sit amet",
     "indexed_date": datetime.now().isoformat(),
 }
+
+
+def test_truncate_str() -> None:
+    s = "e\u0301"  # é
+    assert truncate_str(s, 0) == ""
+    assert truncate_str(s, 1) == ""
+    assert truncate_str(s, 2) == "é"
+    # Without normalizing to "NFC", e and \u0301 are kept separate
+    assert truncate_str(s, 1, normalize=False) == "e"
+    assert truncate_str(s, 2, normalize=False) == "é"
 
 
 class TestElasticsearchConf:

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -42,13 +42,13 @@ def truncate_str(
     encoded as utf-8.
     """
     if src:
-        src_bytes = src.encode(encoding="utf-8", errors="ignore")
+        src_bytes = src.encode(encoding="utf-8", errors="replace")
     if not src or len(src_bytes) <= max_length:
         return src
     if normalize:
         n_src = unicodedata.normalize("NFC", src)
-        src_bytes = n_src.encode(encoding="utf-8", errors="ignore")
-    return src_bytes[:max_length].decode(encoding="utf-8", errors="ignore")
+        src_bytes = n_src.encode(encoding="utf-8", errors="replace")
+    return src_bytes[:max_length].decode(encoding="utf-8", errors="replace")
 
 
 class ElasticsearchImporter(ElasticMixin, StoryWorker):

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -41,14 +41,14 @@ def truncate_str(
     returns a utf-8 prefix of src guaranteed to fit within max_length when
     encoded as utf-8.
     """
-    if not src or len(src) <= max_length:
+    if src:
+        src_bytes = src.encode(encoding="utf-8", errors="ignore")
+    if not src or len(src_bytes) <= max_length:
         return src
-
-    n_src = src
     if normalize:
-        n_src = unicodedata.normalize("NFC", n_src)
-    n_src_bytes = n_src.encode(encoding="utf-8", errors="ignore")[:max_length]
-    return n_src_bytes.decode(encoding="utf-8", errors="ignore")
+        n_src = unicodedata.normalize("NFC", src)
+        src_bytes = n_src.encode(encoding="utf-8", errors="ignore")
+    return src_bytes[:max_length].decode(encoding="utf-8", errors="ignore")
 
 
 class ElasticsearchImporter(ElasticMixin, StoryWorker):

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -140,7 +140,7 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
             content_metadata.parsed_date or datetime.utcnow().isoformat()
         )
 
-        # We need to unsure text_content does not exceed the underlying
+        # We need to ensure that text_content does not exceed the underlying
         # Lucene’s term byte-length limit
         text_content = str(data["text_content"])
         data["text_content"] = truncate_str(text_content)

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -140,9 +140,9 @@ class ElasticsearchImporter(ElasticMixin, StoryWorker):
             content_metadata.parsed_date or datetime.utcnow().isoformat()
         )
 
-        # We need to ensure that text_content does not exceed the underlying
-        # Lucene’s term byte-length limit
-        url = data.get("url")  # for testing, hashing, logging
+        # We need to ensure that text_content exists and it does not exceed the
+        # underlying Lucene’s term byte-length limit
+        url = data.get("url")  # for logging
         if not isinstance(url, str) or url == "":
             # exceedingly unlikely, but must check to keep
             # mypy quiet, so might as well do something rather


### PR DESCRIPTION
### Description

In Elasticsearch, for `text` field to be indexable (i.e. `keyword`), it's length must not exceed the underlying Lucene’s term byte-length limit of **32766**. This PR truncates the `text_content` field if and when it exceeds this limit.