### PR TITLE
Updates for production historical file processing

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -210,6 +210,10 @@ historical)
     # unless archives disabled, prefix will end with:
     ARCH_SUFFIX=hist$HIST_YEAR
     #IMPORTER_ARGS=--no-output	# uncomment to disable archives
+    if [ "x$DEPLOY_TYPE" = xprod ]; then
+	HIST_FETCHER_REPLICAS=8
+	PARSER_REPLICAS=16
+    fi
     PIPE_TYPE_PFX='hist-'	# own stack name/queues
     PIPE_TYPE_PORT_BIAS=200	# own port range (ES has 9200+9300)
     # maybe require command line option to select file(s)?

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -42,7 +42,7 @@ else:
 from indexer.app import AppException
 from indexer.story import BaseStory
 from indexer.storyapp import StoryProducer, StorySender
-from indexer.tracker import TrackerStatus, get_tracker
+from indexer.tracker import TrackerException, get_tracker
 
 logger = logging.getLogger(__name__)
 
@@ -405,10 +405,10 @@ class Queuer(StoryProducer):
                 logger.error("%s failed: %r", fname, e)
                 incr_files("failed")
                 raise
-        except TrackerStatus as exc:
-            # here if file state other than "NOT_STARTED"
-            logger.info("%s: %s", fname, exc)
-            return
+        except TrackerException as exc:
+            # here if file not startable
+            # or could not write to tracker database
+            logger.info("%s: %r", fname, exc)
 
     def main_loop(self) -> None:
         assert self.args

--- a/indexer/tracker.py
+++ b/indexer/tracker.py
@@ -6,12 +6,12 @@ Would prefer something replicated/durable (S3, AWS SimpleDB, ES)
 see https://github.com/mediacloud/story-indexer/issues/203
 """
 
-import dbm
 import logging
 import os
+import sqlite3
 import time
 from enum import Enum
-from typing import Any, Callable, Type, cast
+from typing import Any, Optional, Tuple, Type
 
 from indexer.app import AppException
 from indexer.path import DATAROOT
@@ -19,12 +19,27 @@ from indexer.path import DATAROOT
 # basename assumes URLs and local paths both use "/":
 assert os.path.sep == "/"
 
+OLD_SECONDS = 24 * 60 * 60  # age before eligible for cleanup
+
 logger = logging.getLogger(__name__)
 
 
-class TrackerException(AppException):
+class _TrackerException(AppException):
+    """
+    base class for FileTracker exceptions
+    """
+
+
+class TrackerStatus(_TrackerException):
     """
     thrown when file is in some state other than NOT_STARTED
+    """
+
+
+class _TrackerRetry(_TrackerException):
+    """
+    INTERNAL: thrown when a (local file based) tracker is locked
+    and should be retried
     """
 
 
@@ -37,18 +52,19 @@ class FileStatus(Enum):
 
     NOT_STARTED = 1
     STARTED = 2  # processing started
-    EXPIRED = 3  # started, not finished in expected time
-    FINISHED = 4
+    FINISHED = 3
 
 
 class FileTracker:
-    def __init__(self, app_name: str, fname: str):
+    """
+    class to track input files
+    """
+
+    def __init__(self, app_name: str, fname: str, cleanup: bool):
         self.app_name = app_name
         self.full_name = fname  # saved
         self.fname = self.basename(fname)
-        # subclass should
-        # raise TrackerException(getattr(FileStatus, status).name)
-        # if status != NOT_STARTED!
+        self.cleanup = cleanup
 
     def basename(self, fname: str) -> str:
         """
@@ -72,21 +88,25 @@ class FileTracker:
         return base
 
     def __enter__(self) -> "FileTracker":
-        self._set_status(FileStatus.STARTED)
+        """
+        atomically check if NOT_STARTED, and if so, mark STARTED.
+        subclasses should raise TrackerStatus(status.name)
+        if status != NOT_STARTED
+        """
+        self._start_if_available()
         return self
 
     def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
         if traceback:
-            self._set_status(FileStatus.NOT_STARTED)
+            self._set_status(FileStatus.NOT_STARTED)  # here on error
         else:
             self._set_status(FileStatus.FINISHED)
-        self._cleanup()
+
+    def _start_if_available(self) -> None:
+        raise NotImplementedError("_start_if_available not overridden")
 
     def _set_status(self, status: FileStatus) -> None:
         raise NotImplementedError("_set_status not overridden")
-
-    def _cleanup(self) -> None:
-        raise NotImplementedError("_cleanup not overridden")
 
 
 class DummyFileTracker(FileTracker):
@@ -94,20 +114,24 @@ class DummyFileTracker(FileTracker):
     file tracker that never says no (for debug/test)
     """
 
-    def _set_status(self, status: FileStatus) -> None:
+    def _start_if_available(self) -> None:
         pass
 
-    def _cleanup(self) -> None:
+    def _set_status(self, status: FileStatus) -> None:
         pass
 
 
 class LocalFileTracker(FileTracker):
     """
-    a file tracker that uses a local directory for data storage
+    a file tracker that uses local storage (with a single lock & retries)
+    Local concurrent access is safe.
+    NFS access at your own risk/funeral!!!
     """
 
-    def __init__(self, app_name: str, fname: str):
-        super().__init__(app_name, fname)
+    FILE_EXT: str
+
+    def __init__(self, app_name: str, fname: str, cleanup: bool):
+        super().__init__(app_name, fname, cleanup)
         self._app_data_dir = DATAROOT()
         if not os.path.isdir(self._app_data_dir):
             logger.warning("%s directory not found", self._app_data_dir)
@@ -115,55 +139,172 @@ class LocalFileTracker(FileTracker):
         self._work_dir = os.path.join(self._app_data_dir, self.app_name)
         if not os.path.isdir(self._work_dir):
             os.mkdir(self._work_dir)
+        self._db_path = os.path.join(self._work_dir, f"file-tracker.{self.FILE_EXT}")
 
-
-class DBMFileTracker(LocalFileTracker):
-    """
-    HOPEFULLY TEMPORARY!!!
-    NOTE!!!! GDBM locks file for exclusive access!!
-    Will see:
-    _gdbm.error: [Errno 11] Resource temporarily unavailable
-
-    Local concurrent access is likely safe?
-    NFS access at your own risk/funeral.
-    """
-
-    def __init__(self, app_name: str, fname: str):
-        super().__init__(app_name, fname)
-        path = os.path.join(self._work_dir, "file-tracker.db")
-        # GDBM takes advisory lock!!! cleanup *MUST* be called!!!
-        self._dbm = dbm.open(path, "c", 0o644)
-        # NOTE! self.fname is "basename" without path or .gz
-        status, ts = self._dbm.get(self.fname, b"NOT_STARTED,0").decode().split(",")
-        if status != "NOT_STARTED":
-            self._cleanup()
-            raise TrackerException(getattr(FileStatus, status).name)
+    def _start_if_available(self) -> None:
+        try:
+            self._retry_open_and_lock()
+            status, ts = self._db_get_status_time()
+            logger.debug("_start_if_available %s %d", status, ts)
+            if status == FileStatus.NOT_STARTED.name or (
+                self.cleanup
+                and status == FileStatus.STARTED.name
+                and (time.time() - ts) > OLD_SECONDS
+            ):
+                self._set_status(FileStatus.STARTED)
+            else:
+                raise TrackerStatus(status)
+        finally:
+            self._db_close()
 
     def _set_status(self, status: FileStatus) -> None:
+        logger.info("%s now %s", self.fname, status.name)
+        try:
+            self._retry_open_and_lock()
+            self._db_set_status_time(status, time.time())
+        finally:
+            self._db_close()
+
+    def _retry_open_and_lock(self) -> None:
+        """
+        GDBM and SQLite3 can both raise exceptions when DB locked
+        """
+        for sec in (0.0625, 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0):
+            try:
+                self._db_open_and_lock()
+                return
+            except _TrackerRetry:
+                logger.debug("_retry_open_and_lock sleeping %g", sec)
+                time.sleep(sec)
+        raise TrackerStatus("locked")
+
+    def _db_open_and_lock(self) -> None:
+        raise NotImplementedError("_db_open_and_lock")
+
+    def _db_get_status_time(self) -> Tuple[str, int]:
+        raise NotImplementedError("_get_status_time")
+
+    def _db_set_status_time(self, status: FileStatus, ts: float) -> None:
+        raise NotImplementedError("_db_set_status_time not overridden")
+
+    def _db_close(self) -> None:
+        raise NotImplementedError("_db_close")
+
+
+if False:
+    import dbm.gnu
+    import errno
+
+    class GDBMFileTracker(LocalFileTracker):
+        """
+        Temporarily retained as an alternate example
+        No longer holds file lock while processing,
+        but SQLite file is easier to examine, backup and modify!
+        """
+
+        FILE_EXT = "db"
+        _DEF_VAL = FileStatus.NOT_STARTED.name.encode() + ",0"
+
+        def __init__(self, app_name: str, fname: str, cleanup: bool):
+            self._dbm: Optional[dbm.gnu._gdbm] = None
+            super().__init__(app_name, fname, cleanup)
+
+        def _open_and_lock(self) -> None:
+            if self._dbm:
+                return
+            try:
+                self._dbm = dbm.gnu.open(self._db_path, "c")
+            except OSError as e:
+                if e.errno == errno.EAGAIN:
+                    raise _TrackerRetry()
+                raise
+
+        def _db_get_status_time(self) -> Tuple[str, int]:
+            assert self._dbm
+            val = self._dbm.get(self.fname, self._DEF_VAL).decode()
+            status, ts = val.split(",")
+            return (status, int(ts))
+
+        def _db_set_status_time(self, status: FileStatus, ts: float) -> None:
+            assert self._dbm
+            if status == FileStatus.NOT_STARTED:
+                del self._dbm[self.fname]
+            else:
+                status_string = f"{status.name},{int(ts)}"
+                self._dbm[self.fname] = status_string.encode()
+
+        def _db_close(self) -> None:
+            if self._dbm:
+                self._dbm.close()
+                self._dbm = None
+
+
+_SQL3_CREATE_TABLE = (
+    "CREATE TABLE IF NOT EXISTS "
+    "files (name TEXT PRIMARY KEY, status TEXT NOT NULL, ts INTEGER) "
+    "WITHOUT ROWID"
+)
+
+
+class SQLite3FileTracker(LocalFileTracker):
+    """
+    easier to view, back up and mody than GDBM
+    SHOULD ONLY BE USED LOCALLY (all Queuers on one node)!!!
+    """
+
+    FILE_EXT = "sqlite3"
+
+    def __init__(self, app_name: str, fname: str, cleanup: bool):
+        self._conn: Optional[sqlite3.Connection] = None
+        super().__init__(app_name, fname, cleanup)
+
+    def _db_open_and_lock(self) -> None:
+        if self._conn:
+            return
+        self._conn = sqlite3.connect(self._db_path)
+        self._conn.execute(_SQL3_CREATE_TABLE)
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError:
+            raise _TrackerRetry()
+
+    def _db_set_status_time(self, status: FileStatus, ts: float) -> None:
+        assert self._conn
         if status == FileStatus.NOT_STARTED:
-            del self._dbm[self.fname]
+            self._conn.execute("DELETE FROM files WHERE name = ?", (self.fname,))
         else:
-            status_string = f"{status.name},{int(time.time())}"
-            self._dbm[self.fname] = status_string.encode()
-        sync = getattr(self._dbm, "sync")
-        if sync is not None:
-            csync = cast(Callable[[], None], sync)
-            csync()
+            self._conn.execute(
+                "INSERT OR REPLACE INTO files VALUES (?,?,?)",
+                (self.fname, status.name, int(ts)),
+            )
+        self._conn.execute("COMMIT")
 
-    def _cleanup(self) -> None:
-        """
-        NOTE! GDBM takes exclusive lock!!!
-        """
-        if self._dbm:
-            self._dbm.close()
-            del self._dbm
+    def _db_get_status_time(self) -> Tuple[str, int]:
+        assert self._conn
+        cursor = self._conn.execute(
+            "SELECT status, ts FROM files WHERE name = ?", (self.fname,)
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return FileStatus.NOT_STARTED.name, 0
+        return str(row[0]), int(row[1])
+
+    def _db_close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
 
 
-def get_tracker(app_name: str, fname: str, force: bool) -> FileTracker:
+def get_tracker(app_name: str, fname: str, force: bool, cleanup: bool) -> FileTracker:
+    """
+    force: process all files, do not update database
+    cleanup: treat old STARTED entries as NOT_STARTED
+    """
     # complex decision process:
     cls: Type[FileTracker]
     if force:
         cls = DummyFileTracker  # always says yes
     else:
-        cls = DBMFileTracker
-    return cls(app_name, fname)
+        # _could_ look for existing local file.
+        cls = SQLite3FileTracker
+    return cls(app_name, fname, cleanup)

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -88,6 +88,9 @@ class HistQueuer(Queuer):
                     # timestamp of the time the HTML was fetched,
                     # to preserve this otherwise unused bit of information.
 
+                    if len(collect_date) < 20:
+                        collect_date += ".0"  # ensure fraction present
+
                     # fromisoformat wants EXACTLY six digits of fractional
                     # seconds, but the CSV files omit trailing zeroes, so
                     # use strptime.  Append UTC timezone offset to prevent


### PR DESCRIPTION
* Increase fetcher and parser container counts.
* Add --cleanup option to re-start orphaned files
* Use SQLite3 for local tracking DB: easier to view, back up and modify
* Handle CSV date/times without fractional seconds