### PR TITLE
Fix/ilm handle duplicates

### DIFF
--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -191,7 +191,6 @@ class TestElasticsearchImporter:
             },
         )
         assert search_response
-        print(search_response["hits"]["hits"])
         search_response_keys = search_response["hits"]["hits"][0]["_source"]
         additional_keys = {
             key: test_import_data[key]

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -190,7 +190,8 @@ class TestElasticsearchImporter:
                 "query": {"bool": {"filter": {"term": {"_id": id}}}},
             },
         )
-        assert search_response
+        assert search_response["hits"]["hits"], "No document in search response"
+
         search_response_keys = search_response["hits"]["hits"][0]["_source"]
         additional_keys = {
             key: test_import_data[key]

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -184,9 +184,8 @@ class TestElasticsearchImporter:
             **test_extra_data,
             "url": "https://damienafsoe.ttblogs.com/4775282/the-basic-principles-of-would-or-could",
         }
-        response = importer.import_story(test_import_data)
-        assert response
-        id = response.get("_id")
+        id = importer.import_story(test_import_data)
+        assert id
         search_response = importer.elasticsearch_client().search(
             index="test_mc_search",
             body={

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -196,12 +196,7 @@ class TestElasticsearchImporter:
         assert search_response["hits"]["hits"], "No document in search response"
 
         search_response_keys = search_response["hits"]["hits"][0]["_source"]
-        additional_keys = {
-            key: test_import_data[key]
-            for key in test_import_data
-            if key not in test_data
-        }
-        for key in additional_keys:
+        for key in test_extra_data:
             assert (
                 key not in search_response_keys.keys()
             ), f"Unexpected field '{key}' found in response."

--- a/indexer/tests/test_importer.py
+++ b/indexer/tests/test_importer.py
@@ -174,12 +174,15 @@ class TestElasticsearchImporter:
         assert importer.import_story(test_import_data)
 
     def test_import_story_extra_fields(self, importer: ElasticsearchImporter) -> None:
-        test_import_data = {
-            **test_data,
-            "url": "https://damienafsoe.ttblogs.com/4775282/the-basic-principles-of-would-or-could",
+        test_extra_data = {
             "normalized_article_title": "the basic principles of would or could",
             "normalized_url": "http://damienafsoe.ttblogs.com/4775282/the-basic-principles-of-would-or-could",
             "text_extraction_method": "trafilatura",
+        }
+        test_import_data = {
+            **test_data,
+            **test_extra_data,
+            "url": "https://damienafsoe.ttblogs.com/4775282/the-basic-principles-of-would-or-could",
         }
         response = importer.import_story(test_import_data)
         assert response

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -169,7 +169,7 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
     def import_story(
         self,
         data: dict[str, Optional[Union[str, bool]]],
-    ) -> ObjectApiResponse | None:
+    ) -> str | None:
         """
         True if story imported to ES, and should be archived,
         False if a duplicate,

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -219,7 +219,6 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
         except ConflictError:
             self.incr_stories("dups", url)
             return None
-        # return False
         except RequestError as e:
             # here with over-length content!
             self.incr_stories("reqerr", url)

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -215,7 +215,7 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
             # (that should never be seen) should be returned as False (do not archive).
             result = response.get("result", "noresult") or "emptyres"
             self.incr_stories(result, url)  # count, logs result, URL
-            return response
+            return url_hash # i.e. response.get("_id")
         except ConflictError:
             self.incr_stories("dups", url)
             return None

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -194,8 +194,7 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
             )
             if search_response["hits"]["total"]["value"] > 0:
                 self.incr_stories("dups", url)
-                # return False
-                return None
+                return None  # mypy explicit return
             # logs HTTP op with index name and ID str.
             # create: raises exception if a duplicate.
             response = self.elasticsearch_client().create(
@@ -217,7 +216,6 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
             result = response.get("result", "noresult") or "emptyres"
             self.incr_stories(result, url)  # count, logs result, URL
             return response
-            # return True
         except ConflictError:
             self.incr_stories("dups", url)
             return None

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -168,11 +168,18 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
     def import_story(
         self,
         data: dict[str, Optional[Union[str, bool]]],
-    ) -> str | None:
+    ) -> Optional[str]:
         """
-        True if story imported to ES, and should be archived,
-        False if a duplicate,
-        else raises an exception.
+        Imports story to Elasticsearch
+
+        Args:
+            data (dict[str, Optional[Union[str, bool]]]): The story data to be imported,
+            containing keys such as 'url' and 'text_content'.
+
+        Returns:
+            Optional[str]: The Elasticsearch document ID (url_hash) if the story is imported,
+            None if it is a duplicate.
+            else raises an exception.
         """
         # data can never be empty (has been checked in process_story, AND
         # "indexed_date", "url" & "text_content" will always be set, so no check here).
@@ -192,7 +199,7 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
                 },
             )
             if search_response["hits"]["total"]["value"] > 0:
-                self.incr_stories("dups", url)
+                self.incr_stories("ilm-dups", url)
                 return None  # mypy explicit return
             # logs HTTP op with index name and ID str.
             # create: raises exception if a duplicate.

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -9,7 +9,6 @@ import unicodedata
 from datetime import datetime
 from typing import Optional, Union, cast
 
-from elastic_transport import ObjectApiResponse
 from elasticsearch.exceptions import ConflictError, RequestError
 from mcmetadata.urls import unique_url_hash
 
@@ -215,7 +214,7 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
             # (that should never be seen) should be returned as False (do not archive).
             result = response.get("result", "noresult") or "emptyres"
             self.incr_stories(result, url)  # count, logs result, URL
-            return url_hash # i.e. response.get("_id")
+            return url_hash  # i.e. response.get("_id")
         except ConflictError:
             self.incr_stories("dups", url)
             return None


### PR DESCRIPTION
This PR introduces document lookup by `id` before indexing to handle duplicates on index rollover.
We're using ILM, with multiple indices mapped to a single alias hence the use of [Search API ](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html)
#242 