### PR TITLE
Queue fetcher updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: black
         language_version: python3.10
   - repo: http://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         entry: bin/pre-commit-wrapper.py mypy

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -266,11 +266,8 @@ class Fetcher(MultiThreadStoryWorker):
         # above three should total to prefetch:
         self.gauge("prefetch", self.prefetch)
 
-        def slots(label: str, count: int) -> None:
-            self.gauge("slots", count, labels=[("status", label)])
-
-        slots("recent", stats.slots)
-        slots("active", stats.active_slots)
+        self.gauge("slots.recent", stats.slots)
+        self.gauge("slots.active", stats.active_slots)
 
     def fetch(self, sess: requests.Session, url: str) -> FetchReturn:
         """

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -320,8 +320,8 @@ class Fetcher(MultiThreadStoryWorker):
             # here with redirect:
             nextreq = resp.next  # PreparedRequest | None
             if nextreq:
-                url = prepreq.url or ""
                 prepreq = nextreq
+                url = prepreq.url or ""
             else:
                 url = ""
 

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -196,7 +196,7 @@ class Fetcher(MultiThreadStoryWorker):
             target_concurrency=self.args.target_concurrency,
             max_delay_seconds=self.busy_delay_seconds,
             conn_retry_seconds=self.args.conn_retry_minutes * 60,
-            min_interval_seconds=MIN_INTERVAL_SECONDS,
+            min_interval_seconds=self.args.min_interval_seconds,
         )
 
         self.set_requeue_delay_ms(1000 * self.busy_delay_seconds)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "boto3 ~= 1.28.44",
   "docker ~= 6.1.0",
   "elasticsearch ~= 8.12.0",
+  # lxml installed by some other package?
   "mediacloud-metadata ~= 0.12.0",
   "pika ~= 1.3.2",
   "rabbitmq-admin ~= 0.2",
@@ -23,8 +24,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "boto3-stubs[s3] ~= 1.34.13",
-  "mypy ~= 1.5.1",
   "jinja2-cli ~= 0.8.2",
+  "lxml-stubs ~= 0.5.1",
+  "mypy ~= 1.5.1",
   "pre-commit ~= 3.4.0",
   "pytest ~= 7.4.2",
   "types-beautifulsoup4 ~= 4.12.0.20240106",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,13 +22,13 @@ boilerpy3==1.0.7
     # via mediacloud-metadata
 boto3==1.28.85
     # via story-indexer (pyproject.toml)
-boto3-stubs==1.34.54
+boto3-stubs==1.34.62
     # via story-indexer (pyproject.toml)
 botocore==1.31.85
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.54
+botocore-stubs==1.34.62
     # via boto3-stubs
 certifi==2024.2.2
     # via
@@ -146,13 +146,15 @@ lxml==4.9.4
     #   readability-lxml
     #   scrapy
     #   trafilatura
+lxml-stubs==0.5.1
+    # via story-indexer (pyproject.toml)
 markupsafe==2.1.5
     # via jinja2
 mediacloud-metadata==0.12.0
     # via story-indexer (pyproject.toml)
 mypy==1.5.1
     # via story-indexer (pyproject.toml)
-mypy-boto3-s3==1.34.14
+mypy-boto3-s3==1.34.62
     # via boto3-stubs
 mypy-extensions==1.0.0
     # via mypy
@@ -166,13 +168,13 @@ numpy==1.26.4
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
-packaging==23.2
+packaging==24.0
     # via
     #   docker
     #   parsel
     #   pytest
     #   scrapy
-parsel==1.8.1
+parsel==1.9.0
     # via
     #   itemloaders
     #   scrapy
@@ -204,7 +206,7 @@ pycparser==2.21
     # via cffi
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==24.0.0
+pyopenssl==24.1.0
     # via scrapy
 pytest==7.4.4
     # via story-indexer (pyproject.toml)
@@ -301,7 +303,7 @@ types-html5lib==1.1.11.20240228
     # via types-beautifulsoup4
 types-pika==1.2.0b1
     # via story-indexer (pyproject.toml)
-types-requests==2.31.0.20240218
+types-requests==2.31.0.20240311
     # via story-indexer (pyproject.toml)
 types-s3transfer==0.10.0
     # via boto3-stubs
@@ -343,7 +345,7 @@ zope-interface==6.2
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.1.1
+setuptools==69.2.0
     # via
     #   nodeenv
     #   scrapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -136,12 +136,12 @@ numpy==1.26.4
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
-packaging==23.2
+packaging==24.0
     # via
     #   docker
     #   parsel
     #   scrapy
-parsel==1.8.1
+parsel==1.9.0
     # via
     #   itemloaders
     #   scrapy
@@ -167,7 +167,7 @@ pycparser==2.21
     # via cffi
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==24.0.0
+pyopenssl==24.1.0
     # via scrapy
 python-dateutil==2.9.0.post0
     # via
@@ -279,7 +279,7 @@ zope-interface==6.2
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.1.1
+setuptools==69.2.0
     # via
     #   scrapy
     #   supervisor


### PR DESCRIPTION
    Take another page from scrapy scheduling internals
    
    Override _on_input_message, which runs in the Pika thread when a new
    message is received from RabbitMQ, and rather than just queuing the
    message to the internal work queue (for consumption by worker
    threads), decode it, and see when it could next be started (using the
    Slot.issue_interval calculated from avg_seconds for request completion
    to keep "next_issue" time).  If the delay is less than the fast delay
    queue time (set with --busy-delay-minutes), use the Pika connection
    "call_later" method to delay putting the message on the work queue
    until it's ripe to be issued.  If the delay is longer than
    busy-delay-minutes, requeue the message to the -fast queue.
    
    This GREATLY reduces use of the -fast queue (lower CPU load) AND means
    that requests can be started as soon as possible, without waiting for
    the message to come around through RabbitMQ (better thruput).
    
    Also: default worker count to the number of available CPU cores.
