### PR TITLE
More queue fetcher fixes/improvements

### DIFF
--- a/indexer/requests_arcana.py
+++ b/indexer/requests_arcana.py
@@ -1,0 +1,97 @@
+"""
+Black magic incantations for reqeusts to allow fetching from as
+many sites as possible.
+
+BE VERY CAREFUL making any changes, because it can/will effect what
+sites will talk to us!!!
+
+YOU HAVE BEEN WARNED!!!
+
+ALSO: some mypy complaints have been disabled.  Getting the type
+signatures right could take hours, and the results would likely be
+easily broken by new versions of Python.
+
+In a file of it's own:
+1. To hide the nastiness
+2. _could_ be pushed into mcmetadata, and used by rss-fetcher???
+"""
+
+import logging
+import ssl
+from typing import MutableMapping
+
+import requests
+import urllib3
+from mcmetadata.webpages import MEDIA_CLOUD_USER_AGENT
+from requests.structures import CaseInsensitiveDict
+
+# Headers as close as possible to Scrapy (only Host is out of place).
+HEADERS: MutableMapping[str, str | bytes] = CaseInsensitiveDict(
+    {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9",
+        "Accept-Language": "en",
+        "User-Agent": MEDIA_CLOUD_USER_AGENT,
+        "Accept-Encoding": "gzip, deflate",
+        # NOTE: Both Connection: close and keep-alive cause npr Akamai https connections to hang!!
+        # (http connections seem to hang regardless)
+    }
+)
+
+logger = logging.getLogger(__name__)
+
+
+# https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled
+class CustomHttpAdapter(requests.adapters.HTTPAdapter):
+    """
+    Transport adapter" that allows us to use custom ssl_context.
+    """
+
+    def __init__(self, ssl_context=None, **kwargs):  # type: ignore[no-untyped-def]
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections: int, maxsize: int, block: bool = False) -> None:  # type: ignore[override]
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
+
+
+def legacy_ssl_session() -> requests.Session:
+    """
+    return a requests "session" object that behaves like OpenSSL 1.1.1
+    while using OpenSSL 3.0, in order to match Scrapy behavior (and
+    most browsers).  DON'T USE THIS IF YOU WANT TO KEEP DATA PRIVATE!!
+    """
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.options |= int(getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4))
+
+    # https://stackoverflow.com/questions/33770129/how-do-i-disable-the-ssl-check-in-python-3-x
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    session = requests.session()
+    # maybe change retry count (since we retry in an hour)??
+    session.mount("https://", CustomHttpAdapter(ctx))
+    session.headers = HEADERS
+
+    return session
+
+
+# https://secariolabs.com/logging-raw-http-requests-in-python/
+def log_http_requests() -> None:
+    """
+    calling this function once to patch code paths so that HTTP
+    request data is logged.  This is useful to see what is being sent.
+    """
+    import http
+
+    old_send = http.client.HTTPConnection.send
+
+    def new_send(self, data):  # type: ignore[no-untyped-def]
+        logger.debug("HTTP %s", data.decode("utf-8").strip())
+        return old_send(self, data)
+
+    http.client.HTTPConnection.send = new_send  # type: ignore[method-assign]

--- a/indexer/requests_arcana.py
+++ b/indexer/requests_arcana.py
@@ -83,8 +83,8 @@ def legacy_ssl_session() -> requests.Session:
 # https://secariolabs.com/logging-raw-http-requests-in-python/
 def log_http_requests() -> None:
     """
-    calling this function once to patch code paths so that HTTP
-    request data is logged.  This is useful to see what is being sent.
+    call this function once to patch code paths so that HTTP
+    requests are logged for test/debug.
     """
     import http
 

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -403,7 +403,6 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         self.workers = self.args.worker_threads
         assert self.workers > 0
 
-        # AFTER setting prefetch:
         super().process_args()
 
         # logging configured by super().process_args()

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -260,8 +260,6 @@ class BatchStoryWorker(StoryWorker):
         )
 
     def process_args(self) -> None:
-        super().process_args()
-
         # leave a minimum of one minute for processing!!!
         assert self.WORK_TIME < CONSUMER_TIMEOUT_SECONDS - 60
         batch_seconds_max = CONSUMER_TIMEOUT_SECONDS - self.WORK_TIME
@@ -278,6 +276,9 @@ class BatchStoryWorker(StoryWorker):
         # buffer exactly one full batch
         # (ACK on all messages delayed until batch processing complete)
         self.prefetch = self.args.batch_size
+
+        # AFTER setting prefetch:
+        super().process_args()
 
     def _process_messages(self) -> None:
         """
@@ -397,8 +398,6 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         )
 
     def process_args(self) -> None:
-        super().process_args()
-
         assert self.args
         self.workers = self.args.worker_threads
         assert self.workers > 0
@@ -407,6 +406,9 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         # default to one message for each worker, plus one read-ahead
         # may be overwritten by subclasses
         self.prefetch = self.workers + 1
+
+        # AFTER setting prefetch:
+        super().process_args()
 
     def _worker_thread(self) -> None:
         """

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -299,7 +299,7 @@ class BatchStoryWorker(StoryWorker):
         msgs: List[InputMessage] = []
 
         logger.info("batch_size %d, batch_seconds %d", batch_size, batch_seconds)
-        while self._state == State.PIKA_THREAD_RUNNING:
+        while self._state == State.RUN_PIKA_THREAD:
             while msg_number <= batch_size:  # msg_number is one-based
                 if msg_number == 1:
                     logger.debug("waiting for first batch message")
@@ -422,7 +422,7 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         body for worker threads
         """
         self._process_messages()
-        if self._state == State.PIKA_THREAD_RUNNING:
+        if self._state == State.RUN_PIKA_THREAD:
             logger.error("_worker_thread _process_messages returned")
         self._worker_errors = True
 
@@ -461,7 +461,7 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         try:
             self._start_worker_threads()
             while True:
-                if self._state != State.PIKA_THREAD_RUNNING:
+                if self._state != State.RUN_PIKA_THREAD:
                     logger.info("_state %s", self._state)
                     break
                 if self._worker_errors:

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -401,7 +401,6 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         assert self.args
         self.workers = self.args.worker_threads
         assert self.workers > 0
-        logger.info("%d workers", self.workers)
 
         # default to one message for each worker, plus one read-ahead
         # may be overwritten by subclasses
@@ -409,6 +408,9 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
 
         # AFTER setting prefetch:
         super().process_args()
+
+        # logging configured by super().process_args()
+        logger.info("%d workers", self.workers)
 
     def _worker_thread(self) -> None:
         """

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -240,7 +240,7 @@ class QApp(App):
             "-U",
             dest="amqp_url",
             default=default_url,
-            help=f"override RABBITMQ_URL ({default_url})",
+            help=f"override RABBITMQ_URL (default {default_url})",
         )
 
         if self.PIKA_LOG_DEFAULT is not None:

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -240,7 +240,7 @@ class QApp(App):
             "-U",
             dest="amqp_url",
             default=default_url,
-            help="override RABBITMQ_URL ({default_url}",
+            help=f"override RABBITMQ_URL ({default_url})",
         )
 
         if self.PIKA_LOG_DEFAULT is not None:

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -181,7 +181,7 @@ def _pika_message_filter(msg: logging.LogRecord) -> bool:
 class State(Enum):
     PIKA_THREAD_NOT_STARTED = 0
     PIKA_THREAD_STARTED = 1
-    PIKA_THREAD_RUNNING = 2
+    RUN_PIKA_THREAD = 2
     STOP_PIKA_THREAD = 3
     PIKA_THREAD_ERROR = 4
     FINISHED = 5
@@ -391,7 +391,7 @@ class QApp(App):
         """
         logger.info("Pika thread starting")
 
-        self._state = State.PIKA_THREAD_RUNNING
+        self._state = State.RUN_PIKA_THREAD
 
         # hook for Workers to make consume calls,
         # (and/or any blocking calls, like exchange/queue creation)
@@ -399,7 +399,7 @@ class QApp(App):
 
         try:
             while True:
-                if self._state != State.PIKA_THREAD_RUNNING:
+                if self._state != State.RUN_PIKA_THREAD:
                     logger.info("pika thread: state %s", self._state)
                     break
                 if not (self.connection and self.connection.is_open):
@@ -632,7 +632,7 @@ class Worker(QApp):
         """
 
         while True:
-            if self._state != State.PIKA_THREAD_RUNNING:
+            if self._state != State.RUN_PIKA_THREAD:
                 logger.info("_process_messages state %s", self._state)
                 break
             if self._app_errors:

--- a/indexer/workers/fetcher/sched.py
+++ b/indexer/workers/fetcher/sched.py
@@ -363,8 +363,13 @@ class Slot:
             # adjust scoreboard counters
             self.sb._slot_finished(self.active == 0)
 
+            # pass everything by keyword
             return FinishRet(
-                old_average, new_average, self.issue_interval, self.active, self.delayed
+                old_average=old_average,
+                new_average=new_average,
+                interval=self.issue_interval,
+                active=self.active,
+                delayed=self.delayed,
             )
 
     def _consider_removing(self) -> None:

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -230,7 +230,7 @@ class Fetcher(MultiThreadStoryWorker):
 
     def periodic(self) -> None:
         """
-        called from main_loop
+        called from main_loop (in Main thread)
         """
         assert self.scoreboard
         assert self.args
@@ -244,14 +244,12 @@ class Fetcher(MultiThreadStoryWorker):
         delayed = stats.delayed - ready
 
         load_avgs = os.getloadavg()
-
-        # when input queue non-empty, first three should total to self.prefetch
         logger.info(
-            "%d active, %d ready, %d delayed, for %d sites, %d recent; lavg %.2f",
+            "%d active, %d sites, %d ready, %d delayed, %d recent, lavg %.2f",
             stats.active_fetches,
+            stats.active_slots,
             ready,
             delayed,
-            stats.active_slots,
             stats.slots,
             load_avgs[0],
         )

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -62,13 +62,19 @@ from indexer.workers.fetcher.sched import (
     StartStatus,
 )
 
-TARGET_CONCURRENCY = 10  # scrapy fetcher AUTOTHROTTLE_TARGET_CONCURRENCY
+# goal for number of concurrent connections to a site
+# (based on Scrapy autothrottle algorithm)
+TARGET_CONCURRENCY = 4
 
-# minimum interval between initiation of requests to a site lower
-# values increase chance of concurrent connections to sites that
+# minimum interval between initiation of requests to a site.
+# Lower values increase chance of concurrent connections to sites that
 # respond quickly, but also increase the chance a site will throttle
 # our requests.
-MIN_INTERVAL_SECONDS = 5
+MIN_INTERVAL_SECONDS = 0.5
+
+# interval to use when site sends HTTP 429 "Too Many Requests".
+# intervals >= than this will be doubled.
+THROTTLE_INTERVAL_SECONDS = MIN_INTERVAL_SECONDS * 2
 
 # default delay time for "fast" queue, and max time to delay stories
 # w/ call_later.  Large values allow more requests to be delayed, so
@@ -171,6 +177,13 @@ class Fetcher(MultiThreadStoryWorker):
         )
 
         ap.add_argument(
+            "--throttle-interval-seconds",
+            type=float,
+            default=THROTTLE_INTERVAL_SECONDS,
+            help=f"initial interval after HTTP 429 (default: {THROTTLE_INTERVAL_SECONDS})",
+        )
+
+        ap.add_argument(
             "--dump-slots",
             default=False,
             action="store_true",
@@ -202,6 +215,7 @@ class Fetcher(MultiThreadStoryWorker):
             conn_retry_seconds=self.args.conn_retry_minutes * 60,
             min_interval_seconds=self.args.min_interval_seconds,
             max_delayed_per_slot=self.prefetch // 4,
+            throttle_interval_seconds=self.args.throttle_interval_seconds,
         )
 
         self.set_requeue_delay_ms(1000 * self.busy_delay_seconds)
@@ -463,12 +477,16 @@ class Fetcher(MultiThreadStoryWorker):
             logger.info("fetch %s", url)
 
             try:  # call retire on exit
+                resp = None
+                status = -1
                 fret = self.fetch(sess, url)
                 conn_status = ConnStatus.NODATA
-                if fret.resp:
-                    if fret.resp.status_code == 200:
+                resp = fret.resp  # requests.Response; do NOT test as bool!
+                if resp is not None:
+                    status = resp.status_code
+                    if status == 200:
                         conn_status = ConnStatus.DATA
-                    elif fret.resp.status_code == 429:
+                    elif status == 429:
                         conn_status = ConnStatus.THROTTLE
             except (
                 requests.exceptions.InvalidSchema,
@@ -503,14 +521,12 @@ class Fetcher(MultiThreadStoryWorker):
                     f.delayed,
                 )
 
-        resp = fret.resp  # requests.Response
         if resp is None:
             self.incr_stories(fret.counter, url)
             if fret.quarantine:
                 raise QuarantineException(fret.counter)
             return
 
-        status = resp.status_code
         if status != 200:
             if status in SEPARATE_COUNTS:
                 counter = f"http-{status}"

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -459,7 +459,8 @@ class Fetcher(MultiThreadStoryWorker):
                 self.incr_stories("skipped", url)
                 raise Retry("skipped due to recent connection failure")
             elif delay == DELAY_LONG:
-                self.incr_stories("requeued", url, log_level=logging.DEBUG)
+                # was:
+                # self.incr_stories("requeued", url, log_level=logging.DEBUG)
                 self._requeue(im)
             else:
                 raise Retry(f"unknown delay {delay}")

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -162,8 +162,8 @@ class Fetcher(MultiThreadStoryWorker):
         1,  # at least one worker!
         int(
             MultiThreadStoryWorker.CPU_COUNT
-            # workers observed to run at most 12% most of the time via top -cH
-            / float(os.environ.get("FETCHER_RUN_FRACTION", 0.12))
+            # workers observed to run, on average about 25% of the time
+            / float(os.environ.get("FETCHER_RUN_FRACTION", 0.25))
             # fraction of CPU cores to occupy:
             * float(os.environ.get("FETCHER_CORE_FRACTION", 0.5))
         ),

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -459,7 +459,7 @@ class Fetcher(MultiThreadStoryWorker):
                 self.incr_stories("skipped", url)
                 raise Retry("skipped due to recent connection failure")
             elif delay == DELAY_LONG:
-                self.incr_stories("delayed", url)
+                self.incr_stories("requeued", url, log_level=logging.DEBUG)
                 self._requeue(im)
             else:
                 raise Retry(f"unknown delay {delay}")

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -209,9 +209,9 @@ class Fetcher(MultiThreadStoryWorker):
 
         ap.add_argument(
             "--dump-slots",
-            default=False,
-            action="store_true",
-            help="dump slot info once a minute",
+            type=str,
+            default=os.environ.get("FETCHER_DUMP_FILE"),
+            help="dump slot info once a minute into named file",
         )
 
     def process_args(self) -> None:

--- a/indexer/workers/fetcher/tqfetcher.py
+++ b/indexer/workers/fetcher/tqfetcher.py
@@ -151,8 +151,8 @@ class Fetcher(MultiThreadStoryWorker):
         1,  # at least one worker!
         int(
             MultiThreadStoryWorker.CPU_COUNT
-            # workers observed to run 50% of time:
-            / float(os.environ.get("FETCHER_RUN_FRACTION", 0.5))
+            # workers observed to run 25% of time:
+            / float(os.environ.get("FETCHER_RUN_FRACTION", 0.25))
             # fraction of CPU cores to occupy:
             * float(os.environ.get("FETCHER_CORE_FRACTION", 2 / 3))
         ),
@@ -215,7 +215,6 @@ class Fetcher(MultiThreadStoryWorker):
         )
 
     def process_args(self) -> None:
-        super().process_args()
         assert self.args
 
         # Make sure cannot attempt a URL twice using old status information:
@@ -231,6 +230,9 @@ class Fetcher(MultiThreadStoryWorker):
         # state (in _message_queue), since there is no inter-request
         # delay enforced once requests land there.
         self.prefetch = self.workers * 2
+
+        # AFTER setting prefetch:
+        super().process_args()
 
         self.scoreboard = ScoreBoard(
             target_concurrency=self.args.target_concurrency,


### PR DESCRIPTION
Fixes to address issues found in latest A/B comparison runs with scrapy/batch fetcher:

created indexer/requests_arcana.py:
* creates requests Session object for maximal scrapy compatibility
* sets headers directly (avoid creating Connection: header)
* add Accept: header (say we prefer text!)
* nasty hackery to make OpenSSL v3 more tolerant of old versions of TLS

worker.py, storyapp.py: create `State` Enum for orderly shutdown of Pika thread to avoid story loss!

tqfetcher.py, sched.py:
* raise minimum interval to 5 seconds
* deal with (russian?!) sites that don't return Content-Type header!!
* add ConnStatus.THROTTLE to respond to HTTP 429 status
* add FinishRet for more/better logging of slot state (to debug/test throttling)
* add tunables: --initial-interval-seconds --initial-interval-seconds
* default number of worker threads with goal of keeping 2/3 of all cores busy
* add max_delayed_per_slot parameter (1/4 of prefetch) so that one site can't gum up processing
* requests.Session is a context handler, so use with statement
* improve request average handling to be closer to scrapy
* add comments
* return & log num_delayed from Scoreboard.get_delay
