### PR TITLE
Enhance BlobStore for access to multiple services, add BackBlaze B2

### DIFF
--- a/indexer/blobstore/S3.py
+++ b/indexer/blobstore/S3.py
@@ -2,32 +2,97 @@
 BlobStore provider for AWS S3 Object Store
 """
 
+import logging
+from typing import TYPE_CHECKING, Any, Generator
+
 import boto3
 import botocore.exceptions
 
-import indexer.blobstore
+from indexer.blobstore import BlobStore, FileObj
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+else:
+    S3Client = Any
 
 
-class S3Error(indexer.blobstore.BlobStoreError):
+logger = logging.getLogger(__name__)
+
+
+class S3Store(BlobStore):
     """
-    thrown on operation failure
+    Class for stores with AWS S3 API using boto3.
+
+    Can add non-AWS services by subclassing and overriding PROVIDER
+    and URL_FORMAT to allow multiple providers at one time!
     """
 
+    PROVIDER = "S3"  # for config names, may be overridden by subclasses!
 
-class S3Store(indexer.blobstore.BlobStore):
-    PROVIDER = "S3"  # for config names
-    EXCEPTIONS = [botocore.exceptions.BotoCoreError, S3Error]
+    URL_FORMAT = "https://s3.{region}.amazonaws.com"
 
-    def __init__(self, store_name: str):
-        super().__init__(store_name)
-        self.s3_bucket = self._conf_val("BUCKET")
-        self.s3 = boto3.client(
+    # used in client code to avoid catching all Exceptions!!
+    EXCEPTIONS = [botocore.exceptions.BotoCoreError]
+
+    def __init__(self, store_name: str, bucket: str | None = None):
+        super().__init__(store_name, bucket)
+
+        region = self._conf_val("REGION")
+
+        # Backblaze B2 calls this "storage application key id"
+        access_key_id = self._conf_val("ACCESS_KEY_ID")
+        # Backblaze B2 calls this "storage application key"
+        secret_access_key = self._conf_val("SECRET_ACCESS_KEY")
+        endpoint_url = self.URL_FORMAT.format(region=region)
+
+        self._s3 = boto3.client(
             "s3",
-            region_name=self._conf_val("REGION"),
-            aws_access_key_id=self._conf_val("ACCESS_KEY_ID"),
-            aws_secret_access_key=self._conf_val("SECRET_ACCESS_KEY"),
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
         )
 
-    def store_from_local_file(self, local_path: str, remote_path: str) -> None:
+    def upload_file(self, local_path: str, remote_key: str) -> None:
         # mypy says it doesn't return a value:
-        self.s3.upload_file(local_path, self.s3_bucket, remote_path)
+        self._s3.upload_file(local_path, self.bucket, remote_key)
+
+    def _key_generator(self, prefix: str) -> Generator[str, None, None]:
+        """
+        originally written as generator, keeping, just in case
+        """
+        marker = ""
+        while True:
+            res = self._s3.list_objects(
+                Bucket=self.bucket, Prefix=prefix, Marker=marker
+            )
+            if "Contents" not in res:
+                return
+            for item in res["Contents"]:
+                key = item["Key"]
+                # XXX filter based on ending?
+                logger.debug("match: %s", key)
+                yield key
+            if not res["IsTruncated"]:
+                return
+            marker = key  # see https://github.com/boto/boto3/issues/470
+            logger.debug("object list truncated; next marker: %s", marker)
+            if not marker:
+                return
+
+    def list_objects(self, prefix: str = "") -> list[str]:
+        return list(self._key_generator(prefix))
+
+    def download_file(self, remote_key: str, local_fname: str) -> None:
+        self._s3.download_file(self.bucket, remote_key, local_fname)
+
+    def download_fileobj(self, remote_key: str, fileobj: FileObj) -> None:
+        self._s3.download_fileobj(Bucket=self.bucket, Key=remote_key, Fileobj=fileobj)
+
+
+class B2Store(S3Store):
+    """
+    BackBlaze using S3 compatible API
+    """
+
+    PROVIDER = "B2"  # for config names
+    URL_FORMAT = "https://s3.{region}.backblazeb2.com"

--- a/indexer/blobstore/__init__.py
+++ b/indexer/blobstore/__init__.py
@@ -1,64 +1,132 @@
 """
-Simple API for file transfer to archive/cold storage.
+Simple API for file transfer to/from archival storage sites.
+
+Original use/purpose/need was to archive WARC files, and queuer had
+its own S3 code to read input (csv) files from S3 (using s3: URLs) for
+simplicity.
+
+But when adding BackBlaze "B2" support, it became clear that
+easy, parallel support for multiple providers was worth pursuing.
+
+BlobStores should be viewed as read-only key/value byte object
+stores and may lack "normal" filesystem ops like append, rename,
+and may lack directory structure (and instead have only string
+prefix matching).
+
+The first provider implemented as S3, and the second completed
+(BackBlaze B2) provides an S3 compatible API, so the method names
+are exactly those provided by boto.
+
+Only the operations needed/used are implemented.
+
+There are two use models:
+
+A program that reads or writes from/to particular, homogeneous
+collections of store objects.  In this case the "store" argument, used
+to find configuration might be the name of the application, or the
+name of a store (ie; ARCHIVE).  The environment should contain
+complete configuration for at least one set of STORE_PROVIDER_VARIABLE
+variables, which MUST include a bucket name.  If the application
+accesses more than one bucket, "store" should refer to the purpose of
+each particular bucket.  The "blobstores()" function returns a list of
+BlobStore instances for all providers for which there is complete
+configuration.
+
+A program that acesses existing objects (e.g. specified on the command
+line) specified by PROVIDER://BUCKET/NAME_OR_PREFIX, and the BlobStore
+object is acquired using "blobstore_by_url()".  The "store" name
+should be either the name of the application (HIST for hist-queuer) or
+of the class of applications the keys in the configuration applies to
+(QUEUER).  The configuration need not specify a bucket, since it will
+be included in the URL.  blobstore_by_url returns the "path" part of
+the URL, which may be treated as a single object name, or a prefix
+(ie; wildcard) used with "bs.list_objects(prefix)" to retrieve all
+matching objects.
 """
 
 import importlib
 import logging
 import os
 import pkgutil
-from typing import List, Optional, Type
+from typing import IO, Any, Type
+
+FileObj = IO[Any]
 
 logger = logging.getLogger(__name__)
 
 
+def _conf_var(store_name: str, provider: str, conf_item: str) -> str:
+    return f"{store_name.upper()}_{provider}_{conf_item}"
+
+
+def _conf_val(store_name: str, provider: str, conf_item: str) -> str:
+    """
+    throws KeyError if value not configured
+    """
+    return os.environ[_conf_var(store_name, provider, conf_item)]
+
+
 class BlobStore:
     """
-    base class for Providers
+    base class for BlobStore providers.
     """
 
-    # for config var prefixes
+    # used for config vars, and to build PROVIDERS map (for urls),
     PROVIDER: str
 
-    # List of exceptions that methods can raise.
+    # List of exceptions that methods can raise, used in client code
+    # to avoid catching Exception!
     # There is no typing annotation for variable length heterogenous tuple!
     # so must use "except tuple(obj.EXCEPTIONS) as e:"
-    EXCEPTIONS: List[Type[Exception]]
+    EXCEPTIONS: list[Type[Exception]]
 
-    def __init__(self, store_name: str):
+    def __init__(self, store_name: str, _bucket: str | None = None):
         self.store_name = store_name
+
+        if _bucket:
+            self.bucket = _bucket
+        else:
+            self.bucket = self._conf_val("BUCKET")
+
         # subclasses MUST raise KeyError if full config not available!
 
     def _conf_var(self, conf_item: str) -> str:
-        return f"{self.store_name.upper()}_{self.PROVIDER}_{conf_item}"
+        return _conf_var(self.store_name, self.PROVIDER, conf_item)
 
     def _conf_val(self, conf_item: str) -> str:
         """
         throws KeyError if value not configured
         MAYBE look without provider as prefix????
         """
-        return os.environ[self._conf_var(conf_item)]
+        return _conf_val(self.store_name, self.PROVIDER, conf_item)
 
-    def authorize(self) -> None:
-        """
-        place authorization code here!
-        """
+    def upload_file(self, local_path: str, remote_key: str) -> None:
+        raise NotImplementedError
 
-    def store_from_local_file(self, local_path: str, remote_path: str) -> None:
+    def list_objects(self, prefix: str) -> list[str]:
+        raise NotImplementedError
+
+    def download_file(self, key: str, local_fname: str) -> None:
+        raise NotImplementedError
+
+    def download_fileobj(self, key: str, fileobj: FileObj) -> None:
         raise NotImplementedError
 
 
-class BlobStoreError(RuntimeError):
+PROVIDERS: dict[str, type[BlobStore]] = {}
+
+
+class BlobStoreError(Exception):
     """
     class for BlobStore errors
     """
 
 
-def blobstore(store_name: str) -> Optional[BlobStore]:
-    """
-    return the first blobstore provider that has complete configuration.
+def _find_providers() -> None:
+    if PROVIDERS:
+        return
 
-    store_name is a prefix for config vars for a specific use ie; ARCHIVER
-    """
+    # loop for all .py files in indexer.blobstore directory
     for finder, modname, ispkg in pkgutil.iter_modules(path=__path__):
         try:
             fullmodname = f"{__name__}.{modname}"
@@ -68,32 +136,102 @@ def blobstore(store_name: str) -> Optional[BlobStore]:
             logger.debug("import of %s failed: %r", fullmodname, e)
             continue
 
-        # look for BlobStore subclasses in module and try to instantiate them!
+        # look for all for BlobStore subclasses in module
         for name in dir(module):
             if name[0].isupper():
-                value = getattr(module, name)
+                cls = getattr(module, name)
                 if (
                     name != "BlobStore"
-                    and isinstance(value, type)
-                    and issubclass(value, BlobStore)
+                    and isinstance(cls, type)
+                    and issubclass(cls, BlobStore)
                 ):
-                    logger.debug("found BlobStore class %s", name)
-                    try:
-                        bs = value(store_name)  # instantiate class
-                    except ImportError as e:
-                        logger.debug("error importing BlobStore %s: %r", name, e)
-                        continue
-                    except KeyError as e:
-                        logger.debug("missing config for BlobStore %s: %r", name, e)
-                        continue
+                    # cls is a BlobStore subclass definition
+                    logger.debug(
+                        "found BlobStore provider %s class %s", cls.PROVIDER, name
+                    )
+                    PROVIDERS[cls.PROVIDER] = cls
 
-                    try:
-                        bs.authorize()
-                        return bs
-                    except tuple(value.EXCEPTIONS) as e:
-                        logger.debug("error authorizng BlobStore %s: %r", name, e)
-                    except KeyError as e:
-                        logger.debug("missing config for BlobStore %s: %r", name, e)
 
-    logger.warning("no working blobstore for %s", store_name)
-    return None
+def blobstores(store_name: str, max: int | None = None) -> list[BlobStore]:
+    """
+    return all blobstore providers that have complete configuration
+    (including bucket).
+
+    Config variables are of the form:
+    {STORE_NAME}_{PROVIDER}_{VARIABLE_NAME}
+    """
+    results: list[BlobStore] = []
+
+    _find_providers()
+    for name, cls in PROVIDERS.items():
+        logger.debug("trying BlobStore provider %s", name)
+        try:
+            bs = cls(store_name)  # instantiate class
+            results.append(bs)
+            if isinstance(max, int) and len(results) == max:
+                return results
+        except KeyError as e:
+            logger.debug("missing config for BlobStore %s: %r", name, e)
+            continue
+
+    if len(results) == 0:
+        logger.warning("no %s blobstores configured", store_name)
+    return results
+
+
+def blobstore(store_name: str) -> BlobStore | None:
+    """
+    backwards compatible call.
+    will have no users after importer updated?
+    """
+    stores = blobstores(store_name, max=1)
+    if len(stores) == 0:
+        return None
+    return stores[0]
+
+
+def split_url(url: str) -> tuple[str, str, str]:
+    """
+    take schema://bucket/key
+    return (schema, bucket, key) from URL
+    """
+    # will raise TypeError if :// not found
+    schema, path = url.split("://", 1)
+    match path.split("/", 1):
+        case [bucket, key]:
+            pass
+        case [bucket]:
+            key = ""
+    return (schema, bucket, key)
+
+
+def is_blobstore_url(path: str) -> bool:
+    """
+    return true if looks like a URL and schema has a known provider name
+    """
+    match path.split("://", 1):
+        case [schema, _]:
+            _find_providers()
+            return schema.upper() in PROVIDERS
+    return False
+
+
+def blobstore_by_url(store: str, url: str) -> tuple[BlobStore, str, str]:
+    """
+    take provider://bucket/key...
+    returns (BlobStore, schema, key_or_prefix)
+
+    NOTE!
+    * config for STORE_PROVIDER_XXX must have access to bucket in URL
+    * key_or_prefix may be empty
+    * key can be passed to bs.list_objects(key) for prefix expansion
+    """
+
+    schema, bucket, key = split_url(url)  # may raise TypeError
+
+    _find_providers()
+    cls = PROVIDERS.get(schema.upper())
+    if cls is None:
+        raise BlobStoreError(f"bad schema {schema}")
+    bs = cls(store, bucket)  # may raise KeyError
+    return (bs, schema, key)

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -40,13 +40,13 @@ logger = logging.getLogger(__name__)
 
 
 class Queuer(StoryProducer):
-    AWS_PREFIX: str  # prefix for environment vars
+    APP_BLOBSTORE: str  # first choice for config
 
     HANDLE_GZIP: bool  # True to intervene if .gz present
 
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
-        self.blobstores = [self.AWS_PREFIX.upper(), "QUEUER"]
+        self.blobstores = [self.APP_BLOBSTORE.upper(), "QUEUER"]
 
     def define_options(self, ap: argparse.ArgumentParser) -> None:
         super().define_options(ap)
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     from indexer.app import run
 
     class TestQueuer(Queuer):
-        AWS_PREFIX = "FOO"
+        APP_BLOBSTORE = "FOO"
         HANDLE_GZIP = True
 
         def process_file(self, fname: str, fobj: BinaryIO) -> None:

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -318,6 +318,9 @@ class StoryArchiveWriter:
         )
         self.writer.write_record(metadata_record)
 
+        # make what archive a story ended up in visible
+        logger.info("%s -> %s", url, self.filename)
+
         return True  # written
 
     def finish(self) -> None:

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ArchiveQueuer(Queuer):
-    AWS_PREFIX = "ARCHIVER"  # same as archiver.py
+    APP_BLOBSTORE = "ARCHIVER"  # same as archiver.py
     HANDLE_GZIP = False  # handled by warcio
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -45,10 +45,11 @@ class Archiver(BatchStoryWorker):
             os.makedirs(self.work_dir)
             logger.info("created work directory %s", self.work_dir)
 
+        # returns list of 0 or more BlobStore provider objects
         self.blobstores = indexer.blobstore.blobstores("ARCHIVER")
         if len(self.blobstores) == 0:
             logger.error("no blobstores found")
-            sys.exit(1)
+            sys.exit(0)  # happy exit (for developers w/o keys)
         logger.info(
             "blobstores configured: %s",
             ", ".join(bs.PROVIDER for bs in self.blobstores),

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -49,6 +49,10 @@ class Archiver(BatchStoryWorker):
         if len(self.blobstores) == 0:
             logger.error("no blobstores found")
             sys.exit(1)
+        logger.info(
+            "blobstores configured: %s",
+            ", ".join(bs.PROVIDER for bs in self.blobstores),
+        )
 
     def process_story(self, sender: StorySender, story: BaseStory) -> None:
         """
@@ -132,7 +136,6 @@ class Archiver(BatchStoryWorker):
                             bs.PROVIDER,
                             remote_path,
                         )
-                        self.maybe_unlink_local(local_path)
                         # XXX keep count for each store instead of last?
                         status = "uploaded"
                     except tuple(bs.EXCEPTIONS) as e:
@@ -141,6 +144,7 @@ class Archiver(BatchStoryWorker):
                         )
                         # XXX keep count for each store instead of last?
                         status = "noupload"
+                self.maybe_unlink_local(local_path)
             else:
                 status = "nostore"
         else:

--- a/indexer/workers/fetcher/rss-queuer.py
+++ b/indexer/workers/fetcher/rss-queuer.py
@@ -44,6 +44,7 @@ def optional_int(input: str | None) -> int | None:
 
 class RSSQueuer(Queuer):
     HANDLE_GZIP = True  # transparently handle .gz files
+    APP_BLOBSTORE = "RSS"  # http from public bucket typically used
 
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -66,6 +66,9 @@ class HistFetcher(StoryWorker):
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
 
+        # NOTE: not using indexer.blobstore.S3.s3_client:
+        # 1. Historical archive is (currently) on S3
+        # 2. This allows defaulting to default keys in ~/.aws/credentials
         for app in ["HIST", "QUEUER"]:
             region = os.environ.get(f"{app}_S3_REGION")
             access_key_id = os.environ.get(f"{app}_S3_ACCESS_KEY_ID")

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -26,7 +26,7 @@ DATE_RE = re.compile(r"(\d\d\d\d)[_-](\d\d)[_-](\d\d)")
 
 
 class HistQueuer(Queuer):
-    AWS_PREFIX = "HIST"  # S3 env var prefix
+    APP_BLOBSTORE = "HIST"  # first choice for blobstore/keys
     HANDLE_GZIP = True  # just in case
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:


### PR DESCRIPTION

    * Allow concurrent use of multiple stores for testing/transition
    * Add B2Store provider (trivial subclass of S3Store)
    * Add blobstore_by_url: takes PROVIDER://bucket/prefix...
    * Use from Queuer class (can use any "provider" in Queuer command line URLs)
    * renamed AWS_PREFIX to APP_BLOBSTORE
    * archiver logs configured blobstores
    * StoryArchiveWriter logs url and filename
    * Only unlink after upload to all blobstores!