### PR TITLE
Added sentry dsn to the news-search-api deployment in docker compose.

### DIFF
--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -140,6 +140,7 @@ x-worker-service-settings: &worker-service-settings
 x-news-search-service-settings: &news-search-service-settings
   environment: &news-search-environment-vars
     <<: *base-environment-vars
+    SENTRY_DSN: {{sentry_dsn}}
     # INDEXES is obsolete, no common vars right now
   image: {{news_search_image}}
   deploy: &news-search-deploy-settings


### PR DESCRIPTION
Necessary for the news-search-api to initialize the sentry sdk, to get traces to their service. 