### PR TITLE
Shuffle stories for all queuers that feed queue fetcher

### DIFF
--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -244,7 +244,7 @@ class Queuer(ShufflingStoryProducer):
                 logger.info("process_file %s", fname)
                 with self.timer("process_file"):  # report elapsed time
                     self.process_file(fname, f)
-                self.flush_shuffle_batch()
+                    self.flush_shuffle_batch()
                 incr_files("success")
         except TrackerException as exc:
             # here if file not startable

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -51,6 +51,8 @@ class Queuer(StoryProducer):
     # will be False when handling WARC files (warcio handles it)
     HANDLE_GZIP: bool  # True to intervene if .gz present
 
+    SHUFFLE_BATCH_SIZE = 2500
+
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
         self.blobstores = [self.APP_BLOBSTORE.upper(), "QUEUER"]
@@ -244,6 +246,7 @@ class Queuer(StoryProducer):
                 logger.info("process_file %s", fname)
                 with self.timer("process_file"):  # report elapsed time
                     self.process_file(fname, f)
+                self.flush_shuffle_batch()
                 incr_files("success")
         except TrackerException as exc:
             # here if file not startable

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -33,7 +33,7 @@ import requests
 
 from indexer.app import AppException
 from indexer.blobstore import blobstore_by_url, is_blobstore_url
-from indexer.storyapp import StoryProducer
+from indexer.storyapp import ShufflingStoryProducer
 from indexer.tracker import TrackerException, get_tracker
 
 logger = logging.getLogger(__name__)
@@ -45,13 +45,11 @@ class QueuerException(AppException):
     """
 
 
-class Queuer(StoryProducer):
+class Queuer(ShufflingStoryProducer):
     APP_BLOBSTORE: str  # first choice for config
 
     # will be False when handling WARC files (warcio handles it)
     HANDLE_GZIP: bool  # True to intervene if .gz present
-
-    SHUFFLE_BATCH_SIZE = 2500
 
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -257,6 +257,9 @@ class RabbitMQStorySender(StorySender):
     def flush(self) -> None:
         """
         shuffle (randomize order) of any saved stories and send them.
+
+        This method MUST be called BEFORE each work unit (file, API
+        response) of stories is marked as "done".
         """
         logger.info("shuffling %d stories", len(self._batch))
         random.shuffle(self._batch)  # randomize order in place
@@ -265,7 +268,7 @@ class RabbitMQStorySender(StorySender):
         self._batch = []
 
         # XXX NOTE!!! should block here here until pika thread has
-        # queued msgs to TabbitMQ so that queuer work is not marked
+        # queued msgs to RabbitMQ so that queuer work is not marked
         # "done" prematurely!!!!  Using a threading.Condition is
         # tempting but would render the calling thread insensitive to
         # death of the Pika thread, so perhaps add a method to the

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -247,6 +247,7 @@ class RabbitMQStorySender(StorySender):
         )
 
     def flush(self) -> None:
+        logger.info("shuffling %d stories", len(self._batch))
         random.shuffle(self._batch)  # randomize order in place
         for bi in self._batch:
             self._send(**bi)
@@ -398,7 +399,7 @@ class StoryProducer(StoryMixin, Producer):
             if self.sender is None:
                 self.sender = self.story_sender()
             self.sender.send_story(story)
-            status = "queued"
+            status = "queuing"  # may be held for shuffling
 
         self.incr_stories(status, url, log_level=level)
 

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -425,16 +425,18 @@ class QApp(App):
             logger.info("Pika thread exiting")
 
     def _call_in_pika_thread(self, cb: Callable[[], None]) -> None:
+        # XXX only acceptable _states RUNNING and NOT_STARTED?
         if self._state == PikaThreadState.NOT_STARTED:
             # here from a QApp in Main thread
             # transactions will NOT be enabled
             # (unless _subscribe is overridden)
-            self.start_pika_thread()
-            # XXX wait for thread startup (connection object available)!?
+            self.start_pika_thread()  # returns with _state == RUNNING
         elif not self._pika_thread or not self._pika_thread.is_alive():
+            # XXX fatal error??
             logger.info("Pika thread not running: %s", cb.__name__)
             return
         elif not (self.connection and self.connection.is_open):
+            # XXX fatal error??
             logger.info("No Pika connection: %s", cb.__name__)
             return
         # RACE HERE, but only on shutdown?

--- a/indexer/workers/arch-queuer.py
+++ b/indexer/workers/arch-queuer.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 class ArchiveQueuer(Queuer):
     APP_BLOBSTORE = "ARCHIVER"  # same as archiver.py
     HANDLE_GZIP = False  # handled by warcio
+    SHUFFLE_BATCH_SIZE = 0  # no fetcher involved!
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:
         reader = StoryArchiveReader(fobj)

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -5,9 +5,7 @@ Media Cloud Archiver Worker
 import logging
 import os
 import socket
-import sys
 import time
-from typing import Optional
 
 import indexer.blobstore
 from indexer.app import run
@@ -27,7 +25,7 @@ class Archiver(BatchStoryWorker):
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
 
-        self.archive: Optional[StoryArchiveWriter] = None
+        self.archive: StoryArchiveWriter | None = None
         self.archive_prefix = os.environ.get("ARCHIVER_PREFIX", "mc")
         self.blobstores: list[indexer.blobstore.BlobStore] = []
 
@@ -47,9 +45,6 @@ class Archiver(BatchStoryWorker):
 
         # returns list of 0 or more BlobStore provider objects
         self.blobstores = indexer.blobstore.blobstores("ARCHIVER")
-        if len(self.blobstores) == 0:
-            logger.error("no blobstores found")
-            sys.exit(0)  # happy exit (for developers w/o keys)
         logger.info(
             "blobstores configured: %s",
             ", ".join(bs.PROVIDER for bs in self.blobstores),

--- a/indexer/workers/fetcher/rss-puller.py
+++ b/indexer/workers/fetcher/rss-puller.py
@@ -22,7 +22,7 @@ import requests
 from indexer.app import AppException, run
 from indexer.cookiejar import CookieJar
 from indexer.story import RSSEntry, StoryFactory
-from indexer.storyapp import StoryProducer
+from indexer.storyapp import ShufflingStoryProducer
 
 Story = StoryFactory()
 
@@ -71,7 +71,7 @@ class StoryJSON(TypedDict):
     fetched_at: str | None  # UTC in DB/ISO format w/o TZ
 
 
-class RSSPuller(StoryProducer):
+class RSSPuller(ShufflingStoryProducer):
     def __init__(self, process_name: str, descr: str):
         super().__init__(process_name, descr)
 

--- a/indexer/workers/fetcher/rss-puller.py
+++ b/indexer/workers/fetcher/rss-puller.py
@@ -96,12 +96,16 @@ class RSSPuller(ShufflingStoryProducer):
 
         # small batches more likely to have all stories from one source
         # (which thawrts the goal of the "shuffle" to make queue more varied).
-        default_batch_size = int(os.environ.get("RSS_FETCHER_BATCH_SIZE", 2500))
+        default_batch_size = (
+            int(os.environ.get("RSS_FETCHER_BATCH_SIZE", "0").strip())
+            or self.SHUFFLE_BATCH_SIZE
+            or 2500
+        )
         ap.add_argument(
             "--rss-fetcher-batch-size",
             type=int,
             default=default_batch_size,
-            help=f"Use rss-fetcher API to fetch stories (default: {default_batch_size})",
+            help=f"Number of stories to fetch at once (default: {default_batch_size})",
         )
 
     def _get_rss_fetcher_value(self, name: str) -> None:

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -28,6 +28,7 @@ DATE_RE = re.compile(r"(\d\d\d\d)[_-](\d\d)[_-](\d\d)")
 class HistQueuer(Queuer):
     APP_BLOBSTORE = "HIST"  # first choice for blobstore/keys
     HANDLE_GZIP = True  # just in case
+    SHUFFLE_BATCH_SIZE = 0  # uses hist-fetcher no shuffling needed
 
     def process_file(self, fname: str, fobj: BinaryIO) -> None:
         """


### PR DESCRIPTION
Moved shuffling from rss-puller into new ShufflingStoryProducer class so everything that feeds into queue fetcher benefits.

This should improve fetch rate for "csv" and "rss" (explicit RSS input files) pipelines for 2022 backfill.