### PR TITLE
Fix three different problems with programs losing RabbitMQ connection

### DIFF
--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -267,23 +267,8 @@ class RabbitMQStorySender(StorySender):
             self._send(**bi)
         self._batch = []
 
-        # XXX NOTE!!! should block here here until pika thread has
-        # queued msgs to RabbitMQ so that queuer work is not marked
-        # "done" prematurely!!!!  Using a threading.Condition is
-        # tempting but would render the calling thread insensitive to
-        # death of the Pika thread, so perhaps add a method to the
-        # Worker class:
-        #
-        #     def synchronize_with_pika_thread(self):
-        #         done = False
-        #         def sync() -> None:
-        #             global done
-        #             done = True
-        #         self._call_in_pika_thread(sync)
-        #         while self._state == PikaThreadState.RUNNING and not done:
-        #             time.sleep(0.1)
-        #
-        # and call it here via self.app.synchronize_with_pika_thread()
+        # block until all currently queued messages sent
+        self.app.synchronize_with_pika_thread()
 
 
 class ArchiveStorySender(StorySender):

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -815,5 +815,7 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
         finally:
             self._queue_kisses_of_death()
             # loop joining workers???
-        # return to main, which
-        # calls cleanup which calls _stop_pika_thread.
+
+        # QApp.cleanup (called from App.main try/finally) calls
+        # _stop_pika_thread.
+        sys.exit(1)  # Workers never exit happy (always restart)

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -791,7 +791,7 @@ class MultiThreadStoryWorker(IntervalMixin, StoryWorker):
 
         # wake up workers (in _process_messages)
         for i in range(0, self.workers):
-            self._message_queue.put(None)
+            self._queue_kiss_of_death()
         # XXX join worker threads?
 
     def periodic(self) -> None:

--- a/indexer/worker.py
+++ b/indexer/worker.py
@@ -414,6 +414,7 @@ class QApp(App):
         finally:
             # tell _process_messages
             self._state = PikaThreadState.STOPPED
+            self._pika_thread_cleanup()
 
             # Trying clean close, in case process_data_events returns
             # with unprocessed events (especially send callbacks).
@@ -425,25 +426,25 @@ class QApp(App):
             logger.info("Pika thread exiting")
 
     def _call_in_pika_thread(self, cb: Callable[[], None]) -> None:
-        # XXX only acceptable _states RUNNING and NOT_STARTED?
+
         if self._state == PikaThreadState.NOT_STARTED:
             # here from a QApp in Main thread
             # transactions will NOT be enabled
             # (unless _subscribe is overridden)
             self.start_pika_thread()  # returns with _state == RUNNING
-        elif not self._pika_thread or not self._pika_thread.is_alive():
-            # XXX fatal error??
-            logger.info("Pika thread not running: %s", cb.__name__)
-            return
-        elif not (self.connection and self.connection.is_open):
-            # XXX fatal error??
-            logger.info("No Pika connection: %s", cb.__name__)
-            return
-        # RACE HERE, but only on shutdown?
+
+        # RACES POSSIBLE FROM HERE ON, BUT ONLY ON SHUTDOWN/ERROR:
+        if self._state != PikaThreadState.RUNNING:
+            logger.info("Pika thread state %s: %s", self._state, cb.__name__)
+            sys.exit(1)
+
+        assert self._pika_thread
+        assert self._pika_thread.is_alive()
+        assert self.connection
+        assert self.connection.is_open
 
         # NOTE! add_callback_threadsafe is documented (in the Pika
         # 1.3.2 comments) as the ONLY thread-safe connection method!!!
-        assert self.connection  # checked above
         self.connection.add_callback_threadsafe(cb)
 
     def _stop_pika_thread(self) -> None:
@@ -469,6 +470,12 @@ class QApp(App):
 
                 # could issue join with timeout.
                 self._pika_thread.join()
+
+    def _pika_thread_cleanup(self) -> None:
+        """
+        Override as needed
+        """
+        pass
 
     def cleanup(self) -> None:
         """
@@ -774,6 +781,18 @@ class Worker(QApp):
             quarantine_queue_name(self.process_name),
             BasicProperties(headers=headers),
         )
+
+    def _pika_thread_cleanup(self) -> None:
+        """
+        Here in Pika thread when exiting
+        """
+        self._queue_kiss_of_death()  # wake main thread
+
+    def _queue_kiss_of_death(self) -> None:
+        """
+        queue a sentinel to wake up other thread(s) on error
+        """
+        self._message_queue.put(None)
 
     def _retry(self, im: InputMessage, e: Exception) -> bool:
         """


### PR DESCRIPTION
Fixes https://github.com/mediacloud/story-indexer/issues/302

This PR contains three commits, one for each problem:
1. MultiThreadStoryWorker.main_loop: exit with error status (only exit condition is pika thread death due to loss of connection to RabbitMQ)
2. Wake main thread (in ordinary Worker) when Pika thread exits.
3. Add QApp.synchronize_with_pika_thread for Queuers to delay updating work tracker until all stories processed by Pika thread.