### PR TITLE
indexer/workers/fetcher/rss-queuer.py: add missing argument to unexpected tag warning

### DIFF
--- a/indexer/workers/fetcher/rss-queuer.py
+++ b/indexer/workers/fetcher/rss-queuer.py
@@ -185,6 +185,7 @@ class RSSQueuer(Queuer):
                 ):
                     logger.warning(
                         "%s: unexpected tag %s path %s",
+                        fname,
                         name,
                         "/".join(path),
                     )


### PR DESCRIPTION
Found while attempting to queue a malformed RSS file!