### PR TITLE
archiver: handle upload failures better, handle .tmp file removal

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -516,7 +516,13 @@ prod|staging)
     cd ..
     ;;
 dev)
-    PRIVATE_CONF_FILE=./dev.sh
+    # NOTE! in SCRIPT_DIR!
+    USER_CONF=$(pwd)/${LOGIN_USER}.sh
+    if [ -f $USER_CONF ]; then
+	PRIVATE_CONF_FILE=$USER_CONF
+    else
+	PRIVATE_CONF_FILE=$(pwd)/dev.sh
+    fi
     ;;
 esac
 
@@ -525,6 +531,7 @@ if [ ! -f $PRIVATE_CONF_FILE ]; then
     echo "FATAL: could not access $PRIVATE_CONF_FILE" 1>&2
     exit 1
 fi
+echo reading config from $PRIVATE_CONF_FILE
 . $PRIVATE_CONF_FILE
 
 # after reading PRIVATE_CONF_FILE!!

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -105,7 +105,6 @@ fi
 # will lose if run non-interactively via ssh (no utmp entry)
 LOGIN_USER=$(who am i | awk '{ print $1 }')
 if [ "x$LOGIN_USER" = x ]; then
-    # XXX fall back to whoami (look by uid)
     echo could not find login user 1>&2
     exit 1
 fi
@@ -517,11 +516,13 @@ prod|staging)
     ;;
 dev)
     # NOTE! in SCRIPT_DIR!
-    USER_CONF=$(pwd)/${LOGIN_USER}.sh
+    USER_CONF=./${LOGIN_USER}.sh
     if [ -f $USER_CONF ]; then
+	# read dev.sh for defaults, then $USER_CONF for overrides
+	. ./dev.sh
 	PRIVATE_CONF_FILE=$USER_CONF
     else
-	PRIVATE_CONF_FILE=$(pwd)/dev.sh
+	PRIVATE_CONF_FILE=./dev.sh
     fi
     ;;
 esac

--- a/indexer/blobstore/S3.py
+++ b/indexer/blobstore/S3.py
@@ -56,6 +56,9 @@ class S3Store(BlobStore):
         # mypy says it doesn't return a value:
         self._s3.upload_file(local_path, self.bucket, remote_key)
 
+    def upload_fileobj(self, fileobj: FileObj, remote_key: str) -> None:
+        self._s3.upload_fileobj(Bucket=self.bucket, Key=remote_key, Fileobj=fileobj)
+
     def _key_generator(self, prefix: str) -> Generator[str, None, None]:
         """
         originally written as generator, keeping, just in case

--- a/indexer/blobstore/__init__.py
+++ b/indexer/blobstore/__init__.py
@@ -103,6 +103,9 @@ class BlobStore:
     def upload_file(self, local_path: str, remote_key: str) -> None:
         raise NotImplementedError
 
+    def upload_fileobj(self, fileobj: FileObj, remote_key: str) -> None:
+        raise NotImplementedError
+
     def list_objects(self, prefix: str) -> list[str]:
         raise NotImplementedError
 

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -129,7 +129,13 @@ METADATA_CONTENT_TYPE = "application/x.mediacloud-indexer+json"
 logger = getLogger(__name__)
 
 
-class ArchiveStoryError(Exception):
+class ArchiveWriterError(RuntimeError):
+    """
+    base for all other ArchiveWriter run time errors
+    """
+
+
+class ArchiveStoryError(ArchiveWriterError):
     """
     error thrown by ArchiveWriter to indicate not saving a Story.
     First arg WILL be used as a counter name!!
@@ -137,7 +143,7 @@ class ArchiveStoryError(Exception):
     """
 
 
-class FileobjError(Exception):
+class FileobjError(ArchiveWriterError):
     """
     error thrown by fileobj method if cannot return fileobj
     """

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -371,7 +371,8 @@ class StoryArchiveWriter:
             if os.path.exists(self.temp_path):
                 os.rename(self.temp_path, self.full_path)
                 logger.info("renamed %s", self.full_path)
-                self._finished = True
+            self._finished = True
+
         # useful data now available:
         # self.filename: archive file name
         # self.full_path: full local path of output file

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -137,11 +137,13 @@ class Archiver(BatchStoryWorker):
                             sec * 1000,
                             labels=[("store", bs.PROVIDER)],
                         )
+                        # could have upload_speed size/sec!
                         logger.info(
-                            "uploaded %s to %s %s in %.3f",
+                            "uploaded %s to %s %s %d b %.3f s",
                             local_path,
                             bs.PROVIDER,
                             remote_path,
+                            size,
                             sec,
                         )
                         # XXX keep count for each store instead of last?


### PR DESCRIPTION
* keep local WARC file if any upload fails (as it did in the past)
* add/use blobstore `upload_fileobj`; will upload archive even if `.tmp` file accidentally removed
* deploy.sh: read `docker/USERNAME.sh`, if it exists, in addition to `dev.sh` for dev stacks
* log and report stats for upload times
* report `noupload` stat if any upload failed
