### PR TITLE
Allow use of canonical URL extraction in historical pipelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: http://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,18 +11,18 @@ repos:
       - id: check-json
       - id: check-toml
   - repo: http://github.com/ambv/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         language_version: python3.10
   - repo: http://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         entry: bin/pre-commit-wrapper.py mypy
         additional_dependencies: ["pip==22.0.*"]
   - repo: http://github.com/pycqa/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8
   - repo: http://github.com/pycqa/isort

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ Media Cloud online news story indexer.
 
 To create an environment for development: run `make install` from the
 command line.  This creates a virtual environment (venv), installs all
-dependencies, and installs a pre-commit hook.
+dependencies, and installs a git pre-commit hook.
 
 ### "linting"
 
 To run all pre-commit hooks, run `make lint` from the command line.
+
+## Other useful targets
+
+Run `make` (or `make help`) to see the list of other useful targets
 
 ### Updating requirements
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,19 @@ Media Cloud online news story indexer.
 
 ### Setup
 
-To create an environment for testing from the command line:
-create and activate a `python3.10` virtual env and then from the root of the
-project, run `make` to install all required dependencies.
+To create an environment for development: run `make install` from the
+command line.  This creates a virtual environment (venv), installs all
+dependencies, and installs a pre-commit hook.
 
-```sh
-python3.10 -m venv venv
-source venv/bin/activate
-make
-```
+### "linting"
+
+To run all pre-commit hooks, run `make lint` from the command line.
 
 ### Updating requirements
 
 Required Python libraries are specified in `pyproject.toml`.
 `requirements.txt` and `requirements-dev.txt` can be regenerated using
 `make upgrade`
-
-
-### Other useful targets
-
-Run `make help` to see the list of other useful targets
 
 ## More documentation
 

--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -24,7 +24,8 @@ class ElasticStats(ElasticMixin, IntervalMixin, App):
                 es = self.elasticsearch_client()
 
                 # see https://github.com/mediacloud/story-indexer/issues/199
-                stats = cast(Dict[str, Any], es.indices.stats())
+                stats = cast(Dict[str, Any], es.indices.stats())  # fetches /_stats
+
                 # top level keys: "_shards", "_all", "indices"
                 all = stats["_all"]
 

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -186,6 +186,11 @@ class ContentMetadata(StoryData):
     # WARC files, populated from WARC metadata record WARC-Date header.
     parsed_date: Optional[str] = None
 
+    # MAY be extracted from <link ... rel="canonical"> or other tags,
+    # if present.  Added October 2024 to recover a month of 2021 stories
+    # stored in S3 without the original URLs.
+    canonical_url: Optional[str] = None
+
 
 CONTENT_METADATA = class_to_member_name(ContentMetadata)
 

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -11,6 +11,9 @@ import cchardet as chardet
 
 from indexer.path import DATAPATH_BY_DATE, STORIES
 
+# passed by hist-queuer.py w/ --allow-no-url option
+NEED_CANONICAL_URL = "http://mediacloud.org/need_canonical_url"
+
 """
 A single story interface object, with typed data fields for each pipeline step,
 context management on each of those step datum, and a serialization scheme.

--- a/indexer/story.py
+++ b/indexer/story.py
@@ -11,8 +11,14 @@ import cchardet as chardet
 
 from indexer.path import DATAPATH_BY_DATE, STORIES
 
-# passed by hist-queuer.py w/ --allow-no-url option
+# passed as URL by hist-queuer.py w/ --allow-no-url option to allow
+# processing HTML that was saved without the original URL!
 NEED_CANONICAL_URL = "http://mediacloud.org/need_canonical_url"
+
+# *NOTE* if more non-URLs are added and need to be checked for in the
+# same places as NEED_CANONICAL_URL (eg; before indexing), maybe add
+# functions in this file to test for the non-URLs rather than
+# spreading the tests out all over the place??
 
 """
 A single story interface object, with typed data fields for each pipeline step,

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -421,6 +421,9 @@ class StoryArchiveReader:
                 expect = "response"
             elif expect == "response":
                 html = record.raw_stream.read()
+                # strip leading HTTP response and headers
+                if html.startswith(b"HTTP/") and (crcr := html.find(b"\r\n\r\n")) > 0:
+                    html = html[crcr + 4 :]
                 expect = "metadata"
             elif expect == "metadata":
                 j = json.load(record.raw_stream)

--- a/indexer/story_archive_writer.py
+++ b/indexer/story_archive_writer.py
@@ -259,6 +259,7 @@ class StoryArchiveWriter:
         cmd = story.content_metadata()
         rhtml = story.raw_html()
 
+        # NOTE! logging original_url (as elsewhere) for log tracing.
         original_url = cmd.original_url or re.link
         url = hmd.final_url or cmd.url or original_url or ""
         html = rhtml.html or b""

--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -299,7 +299,7 @@ class ArchiveStorySender(StorySender):
                 # include expiration_ms?
             }
         }
-        self.writer.write_story(story, extra_metadata)
+        self.writer.write_story(story, extra_metadata, raise_errors=False)
 
 
 class StoryProducer(StoryMixin, Producer):
@@ -374,6 +374,17 @@ class StoryProducer(StoryMixin, Producer):
                 )
             args.max_stories = args.sample_size
             args.random_sample = self.SAMPLE_PERCENT
+
+    def check_output_queues(self) -> None:
+        """
+        snooze while output queues full,
+        ignore if testing with WARC files!
+        """
+
+        assert self.args
+        if self.args.test_file_prefix:
+            return
+        super().check_output_queues()
 
     def story_sender(self) -> StorySender:
         """

--- a/indexer/workers/archiver.py
+++ b/indexer/workers/archiver.py
@@ -126,6 +126,17 @@ class Archiver(BatchStoryWorker):
                 prefix = time.strftime("%Y/%m/%d/", time.gmtime(timestamp))
                 remote_path = prefix + name
                 errors = 0
+
+                # NOTE! If upload fails for any single blobstore, the
+                # file will be left in the work (archiver) directory
+                # without indication of which upload fails.  We've
+                # only used multiple blobstores when switching from S3
+                # to B2, but if multiple stores ever become the norm,
+                # consider having multiple archiver input queues
+                # fed by a fanout exchange, ie; have
+                # two "add_consumer" calls in the "add_worker"
+                # line for importer in pipeline.py
+
                 for bs in self.blobstores:
                     try:
                         fileobj = self.archive.fileobj()  # inside try

--- a/indexer/workers/fetcher/fetch_worker.py
+++ b/indexer/workers/fetcher/fetch_worker.py
@@ -145,6 +145,7 @@ class FetchWorker(StoryProducer):
                 if not hasattr(self, "sender"):
                     self.qconnect()
                     self.sender = self.story_sender()
+                assert self.sender
                 self.sender.send_story(story)
                 status_label = "success"
 

--- a/indexer/workers/hist-fetcher.py
+++ b/indexer/workers/hist-fetcher.py
@@ -159,7 +159,7 @@ class HistFetcher(StoryWorker):
             extras = self.pick_version(dlid, s3path, dldate)
             if not extras:
                 # no object found for dldate epoch:
-                self.incr_stories("epoch-err", url)
+                self.incr_stories("epoch-err", url or str(dlid))
                 return
 
         # need to have whole story in memory (for Story object),
@@ -174,7 +174,7 @@ class HistFetcher(StoryWorker):
                 # let any other Exception cause retry/quarantine
                 error = exc.response.get("Error")
                 if error and error.get("Code") == "404":
-                    self.incr_stories("not-found", url)
+                    self.incr_stories("not-found", url or str(dlid))
                     return
                 raise
 

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -6,6 +6,7 @@ achieve anything close to S3 request rate limit (5500 requests/second
 per prefix)
 """
 
+import argparse
 import csv
 import datetime as dt
 import io
@@ -30,10 +31,23 @@ class HistQueuer(Queuer):
     HANDLE_GZIP = True  # just in case
     SHUFFLE_BATCH_SIZE = 0  # uses hist-fetcher no shuffling needed
 
+    def define_options(self, ap: argparse.ArgumentParser) -> None:
+        super().define_options(ap)
+
+        ap.add_argument(
+            "--allow-no-url",
+            action="store_true",
+            default=False,
+            help="Allow CSV's without URL (depend on canonical URL extraction)",
+        )
+
     def process_file(self, fname: str, fobj: BinaryIO) -> None:
         """
         called for each input file with open binary/bytes I/O object
         """
+        assert self.args
+        url_required = not self.args.allow_no_url
+
         # try extracting date from file name to create fetch_date for RSSEntry.
         m = DATE_RE.match(fname)
         if m:
@@ -56,16 +70,17 @@ class HistQueuer(Queuer):
             logger.debug("%r", row)
 
             url = row.get("url")
-            if not isinstance(url, str) or not url:
-                self.incr_stories("bad-url", repr(url))
-                continue
+            if url_required:
+                if not isinstance(url, str) or not url:
+                    self.incr_stories("bad-url", repr(url))
+                    continue
 
-            if url in urls_seen:
-                self.incr_stories("dups", url)
-                continue
+                if url in urls_seen:
+                    self.incr_stories("dups", url)
+                    continue
 
-            if not self.check_story_url(url):
-                continue  # logged and counted
+                if not self.check_story_url(url):
+                    continue  # logged and counted
 
             dlid = row.get("downloads_id")
             # let hist-fetcher quarantine if bad
@@ -141,7 +156,8 @@ class HistQueuer(Queuer):
             # https://github.com/mediacloud/story-indexer/issues/213#issuecomment-1908583666
 
             self.send_story(story)  # calls incr_story: to increment and log
-            urls_seen.add(url)  # mark URL as seen
+            if url:
+                urls_seen.add(url)  # mark URL as seen
 
 
 if __name__ == "__main__":

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -16,7 +16,7 @@ from typing import BinaryIO, Set
 
 from indexer.app import run
 from indexer.queuer import Queuer
-from indexer.story import StoryFactory
+from indexer.story import NEED_CANONICAL_URL, StoryFactory
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +81,8 @@ class HistQueuer(Queuer):
 
                 if not self.check_story_url(url):
                     continue  # logged and counted
+            else:
+                url = NEED_CANONICAL_URL
 
             dlid = row.get("downloads_id")
             # let hist-fetcher quarantine if bad
@@ -156,7 +158,7 @@ class HistQueuer(Queuer):
             # https://github.com/mediacloud/story-indexer/issues/213#issuecomment-1908583666
 
             self.send_story(story)  # calls incr_story: to increment and log
-            if url:
+            if url != NEED_CANONICAL_URL:
                 urls_seen.add(url)  # mark URL as seen
 
 

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -140,6 +140,8 @@ class Parser(StoryWorker):
 
             canonical_url = cmd.canonical_url
             if not canonical_url or canonical_url == NEED_CANONICAL_URL:
+                # XXX look for first "tag" to distinguish XML/RSS from HTML/doctype???
+                # (including <?xml....> and <!doctype....>)
                 self.incr_stories("no-canonical-url", link)
                 return False  # discard
 

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -143,6 +143,11 @@ class Parser(StoryWorker):
                 self.incr_stories("no-canonical-url", link)
                 return False  # discard
 
+            # now that we FINALLY have a URL, make sure it isn't
+            # from a source we filter out!!!
+            if not self.check_story_url(canonical_url):
+                return False  # already counted and logged
+
             with cmd:
                 # importer calls mcmetadata.urls.unique_url_hash(cmd.url)
                 # which calls normalize_url (cmd.normalized_url is never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "docker ~= 7.1.0",
   "elasticsearch ~= 8.12.0",
   # lxml installed by some other package?
-  "mediacloud-metadata ~= 1.1.0",
+  "mediacloud-metadata ~= 1.2.0",
   "pika ~= 1.3.2",
   "rabbitmq-admin ~= 0.2",
   "statsd_client ~= 1.0.7",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,14 +6,13 @@
 #
 annotated-types==0.7.0
     # via pydantic
-attrs==23.2.0
+attrs==24.2.0
     # via
-    #   automat
     #   service-identity
     #   twisted
-automat==22.10.0
+automat==24.8.1
     # via twisted
-babel==2.15.0
+babel==2.16.0
     # via courlan
 beautifulsoup4==4.12.3
     # via
@@ -26,27 +25,27 @@ boilerpy3==1.0.7
     # via mediacloud-metadata
 boto3==1.28.85
     # via story-indexer (pyproject.toml)
-boto3-stubs==1.34.139
+boto3-stubs==1.34.162
     # via story-indexer (pyproject.toml)
 botocore==1.31.85
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.139
+botocore-stubs==1.35.46
     # via boto3-stubs
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   elastic-transport
     #   requests
     #   sentry-sdk
     #   trafilatura
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via readability-lxml
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   htmldate
     #   requests
@@ -55,9 +54,9 @@ click==8.1.7
     # via nltk
 constantly==23.10.4
     # via twisted
-courlan==1.2.0
+courlan==1.3.1
     # via trafilatura
-cryptography==42.0.8
+cryptography==43.0.3
     # via
     #   pyopenssl
     #   scrapy
@@ -75,15 +74,15 @@ dateparser==1.2.0
     #   mediacloud-metadata
 defusedxml==0.7.1
     # via scrapy
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 docker==7.1.0
     # via story-indexer (pyproject.toml)
-elastic-transport==8.13.1
+elastic-transport==8.15.1
     # via elasticsearch
 elasticsearch==8.12.1
     # via story-indexer (pyproject.toml)
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 faust-cchardet==2.1.19
     # via mediacloud-metadata
@@ -91,7 +90,7 @@ feedfinder2==0.0.4
     # via newspaper3k
 feedparser==6.0.11
     # via newspaper3k
-filelock==3.15.4
+filelock==3.16.1
     # via
     #   tldextract
     #   virtualenv
@@ -99,20 +98,20 @@ furl==2.1.3
     # via mediacloud-metadata
 goose3==3.1.19
     # via mediacloud-metadata
-htmldate==1.7.0
+htmldate==1.8.1
     # via
     #   mediacloud-metadata
     #   trafilatura
 hyperlink==21.0.0
     # via twisted
-identify==2.5.36
+identify==2.6.1
     # via pre-commit
-idna==3.7
+idna==3.10
     # via
     #   hyperlink
     #   requests
     #   tldextract
-incremental==22.10.0
+incremental==24.7.2
     # via twisted
 inflection==0.5.1
     # via pyairtable
@@ -122,7 +121,7 @@ itemadapter==0.9.0
     # via
     #   itemloaders
     #   scrapy
-itemloaders==1.3.1
+itemloaders==1.3.2
     # via scrapy
 jieba3k==0.35.1
     # via newspaper3k
@@ -142,7 +141,7 @@ justext==3.0.1
     # via trafilatura
 langdetect==1.0.9
     # via goose3
-lxml==4.9.4
+lxml==5.1.1
     # via
     #   goose3
     #   htmldate
@@ -154,25 +153,25 @@ lxml==4.9.4
     #   trafilatura
 lxml-stubs==0.5.1
     # via story-indexer (pyproject.toml)
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
     # via story-indexer (pyproject.toml)
-mediacloud-metadata==0.12.0
+mediacloud-metadata==1.2.0
     # via story-indexer (pyproject.toml)
 mypy==1.5.1
     # via story-indexer (pyproject.toml)
-mypy-boto3-s3==1.34.138
+mypy-boto3-s3==1.34.162
     # via boto3-stubs
 mypy-extensions==1.0.0
     # via mypy
 newspaper3k==0.2.8
     # via mediacloud-metadata
-nltk==3.8.1
+nltk==3.9.1
     # via newspaper3k
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.0.0
+numpy==2.1.2
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
@@ -187,11 +186,11 @@ parsel==1.9.1
     #   scrapy
 pika==1.3.2
     # via story-indexer (pyproject.toml)
-pillow==10.4.0
+pillow==11.0.0
     # via
     #   goose3
     #   newspaper3k
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via virtualenv
 pluggy==1.5.0
     # via pytest
@@ -203,25 +202,25 @@ py3langid==0.2.2
     # via mediacloud-metadata
 pyahocorasick==2.1.0
     # via goose3
-pyairtable==2.3.3
+pyairtable==2.3.4
     # via
     #   mc-manage
     #   story-indexer (pyproject.toml)
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   service-identity
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via service-identity
 pycparser==2.22
     # via cffi
-pydantic==2.8.2
+pydantic==2.9.2
     # via pyairtable
-pydantic-core==2.20.1
+pydantic-core==2.23.4
     # via pydantic
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==24.1.0
+pyopenssl==24.2.1
     # via scrapy
 pytest==7.4.4
     # via story-indexer (pyproject.toml)
@@ -232,9 +231,9 @@ python-dateutil==2.9.0.post0
     #   goose3
     #   htmldate
     #   newspaper3k
-pytz==2024.1
+pytz==2024.2
     # via dateparser
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   newspaper3k
     #   pre-commit
@@ -244,7 +243,7 @@ rabbitmq-admin==0.2
     # via story-indexer (pyproject.toml)
 readability-lxml==0.8.1
     # via mediacloud-metadata
-regex==2024.5.15
+regex==2024.9.11
     # via
     #   dateparser
     #   nltk
@@ -273,7 +272,6 @@ sgmllib3k==1.0.0
     # via feedparser
 six==1.16.0
     # via
-    #   automat
     #   feedfinder2
     #   furl
     #   langdetect
@@ -283,7 +281,7 @@ six==1.16.0
     #   surt
     #   url-normalize
     #   warcio
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 statsd-client==1.0.7
     # via story-indexer (pyproject.toml)
@@ -301,27 +299,28 @@ tldextract==5.1.2
     #   newspaper3k
     #   scrapy
     #   surt
-tomli==2.0.1
+tomli==2.0.2
     # via
+    #   incremental
     #   mypy
     #   pytest
-tqdm==4.66.4
+tqdm==4.66.5
     # via nltk
-trafilatura==1.6.4
+trafilatura==1.8.1
     # via mediacloud-metadata
-twisted==24.3.0
+twisted==24.7.0
     # via scrapy
-types-awscrt==0.21.0
+types-awscrt==0.22.4
     # via botocore-stubs
-types-beautifulsoup4==4.12.0.20240511
+types-beautifulsoup4==4.12.0.20241020
     # via story-indexer (pyproject.toml)
-types-html5lib==1.1.11.20240228
+types-html5lib==1.1.11.20241018
     # via types-beautifulsoup4
 types-pika==1.2.0b1
     # via story-indexer (pyproject.toml)
 types-requests==2.31.0.20240406
     # via story-indexer (pyproject.toml)
-types-s3transfer==0.10.1
+types-s3transfer==0.10.3
     # via boto3-stubs
 typing-extensions==4.12.2
     # via
@@ -348,23 +347,23 @@ urllib3==2.0.7
     #   sentry-sdk
     #   trafilatura
     #   types-requests
-virtualenv==20.26.3
+virtualenv==20.27.0
     # via pre-commit
 w3lib==2.2.1
     # via
-    #   itemloaders
     #   parsel
     #   scrapy
 warcio==1.7.4
     # via story-indexer (pyproject.toml)
-zope-interface==6.4.post2
+zope-interface==7.1.1
     # via
     #   scrapy
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.2.0
+setuptools==75.2.0
     # via
+    #   incremental
     #   scrapy
     #   supervisor
     #   zope-interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ cffi==1.17.1
     # via cryptography
 chardet==5.2.0
     # via readability-lxml
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   htmldate
     #   requests
@@ -48,7 +48,7 @@ constantly==23.10.4
     # via twisted
 courlan==1.3.1
     # via trafilatura
-cryptography==43.0.1
+cryptography==43.0.3
     # via
     #   pyopenssl
     #   scrapy
@@ -68,7 +68,7 @@ defusedxml==0.7.1
     # via scrapy
 docker==7.1.0
     # via story-indexer (pyproject.toml)
-elastic-transport==8.15.0
+elastic-transport==8.15.1
     # via elasticsearch
 elasticsearch==8.12.1
     # via story-indexer (pyproject.toml)
@@ -127,7 +127,7 @@ lxml==5.1.1
     #   readability-lxml
     #   scrapy
     #   trafilatura
-mediacloud-metadata==1.1.0
+mediacloud-metadata==1.2.0
     # via story-indexer (pyproject.toml)
 newspaper3k==0.2.8
     # via mediacloud-metadata
@@ -147,7 +147,7 @@ parsel==1.9.1
     #   scrapy
 pika==1.3.2
     # via story-indexer (pyproject.toml)
-pillow==10.4.0
+pillow==11.0.0
     # via
     #   goose3
     #   newspaper3k
@@ -271,13 +271,13 @@ w3lib==2.2.1
     #   scrapy
 warcio==1.7.4
     # via story-indexer (pyproject.toml)
-zope-interface==7.0.3
+zope-interface==7.1.1
     # via
     #   scrapy
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.1.0
+setuptools==75.2.0
     # via
     #   incremental
     #   scrapy


### PR DESCRIPTION
This is to allow processing saved HTML from S3 that we don't have the original URLs for!

Requires passing `--allow-no-urls` to hist-queuer, likely to be run with local CSV files (in the worker_data volume) ie;

```
./docker/deploy.sh -a -T historical -Y 2021 -I '--allow-no-url /app/data/ids.csv'
```
Where ids.csv contains a single column `downloads_id`

Trying to pass around stories with no URL caused no end of headaches, so added
```
NEED_CANONICAL_URL = "http://mediacloud.org/need_canonical_url"
```
(which only hist-queuer.py and parser.py know about).

Split parser.py process_story method into parts (_decode_content and _save_metadata) to keep flake8 happy

Makefile "adjustments":
* "make install"
  + creates venv (if needed) and uses it (so no need to make venv & activate: I've been bitten *MANY* times!)
  + *installs pre-commit hook*
* "make lint" always uses venv to run pre-commit
* "make help" is now the default action!

Footnote: Since mypy has never worked the same from the dev venv as it does under pre-commit, I think we can remove mypy and stubs from the dev environment. In the sitemap-tools repo the stubs are in a "pre-commit" list in the optional-dependencies -- the only "dev" dependency is pre-commit!!  I came up with a simpler pre-commit wrapper shell script [.pre-commit-run.sh](https://github.com/mediacloud/sitemap-tools/blob/main/.pre-commit-run.sh) that's used in the .precommit-config.yaml file.   I guess for story-indexer we'd want to build a requirements-pre-commit.txt to use!