### PR TITLE
indexer/workers/parser.py: use lxml iterparse w/ NEED_CANONICAL_URL (PROPOSAL FOR DISCUSION)

### DIFF
--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -3,6 +3,7 @@ metadata parser pipeline worker
 """
 
 import datetime as dt
+import io
 import logging
 from collections import Counter
 from typing import Any
@@ -11,6 +12,10 @@ from typing import Any
 import mcmetadata
 from bs4.dammit import UnicodeDammit
 
+# xml.etree.ElementTree.iterparse doesn't have recover argument
+# (fatal error on control characters in element text), so using lxml
+from lxml.etree import iterparse
+
 # local:
 from indexer.app import run
 from indexer.story import NEED_CANONICAL_URL, BaseStory
@@ -18,6 +23,7 @@ from indexer.storyapp import StorySender, StoryWorker
 from indexer.worker import QuarantineException
 
 QUARANTINE_DECODE_ERROR = True  # discard if False
+FEED_TAGS = ("rss", "feed", "rdf", "channel")  # must be tuple for startswith
 
 logger = logging.getLogger("parser")
 
@@ -120,75 +126,6 @@ class Parser(StoryWorker):
 
         return html
 
-    def _identify_document(self, html: str) -> str:
-        """
-        here with a historical document without a canonical url,
-        make a crude effort to figure out what the document is,
-        return a counter name for monitoring!
-        """
-        top = html[:2048].lower()
-        default = "unknown"
-        skip = 0
-        while True:
-            # if skip > 0, skip to next ">"?
-            skip = top.find("<", skip)
-            if skip == -1:
-                break
-
-            skip += 1
-            if top.startswith(("!doctype", "html", "head", "body"), skip):
-                return "no-cannonical-url"  # HTML
-
-            if top[skip] == "!":  # includes <!--
-                skip += 1
-                continue  # inconclusive
-
-            if top.startswith("?xml", skip):
-                skip += 4
-                default = "xml"
-                continue  # inconclusive
-
-            if top.startswith(("rss", "feed", "rdf", "channel"), skip):
-                return "feed"
-
-            break
-        return default
-
-    def _check_canonical_domain(self, story: BaseStory, html: str) -> str:
-        """
-        should only get here with S3 object id in rss.link
-        (historical data from S3 for Nov/Dec 2021 w/o CSV file)
-        """
-        link = story.rss_entry().link or "SNH"  # for logging
-
-        cmd = story.content_metadata()
-        canonical_url = cmd.canonical_url
-        if not canonical_url or canonical_url == NEED_CANONICAL_URL:
-            counter = self._identify_document(html)
-            self.incr_stories(counter, link)
-            return ""  # discard
-
-        # now that we FINALLY have a URL, make sure it isn't
-        # from a source we filter out!!!
-        if not self.check_story_url(canonical_url):
-            return ""  # logged & counted: discard
-
-        with cmd:
-            # importer calls mcmetadata.urls.unique_url_hash(cmd.url)
-            # which calls normalize_url (cmd.normalized_url is never
-            # used in story-indexer).
-            cmd.url = canonical_url
-
-        # story_archive_writer wants hmd.final_url
-        with story.http_metadata() as hmd:
-            hmd.final_url = canonical_url
-
-        # In this case rss.link is the downloads_id (S3 object id).
-        logger.info("%s: using canonical_url %s", link, canonical_url)
-
-        # NOTE! Cannot call "incr_stories": would cause double counting!
-        return canonical_url
-
     def _save_metadata(self, story: BaseStory, mdd: dict[str, Any], html: str) -> bool:
         # XXX check for empty text_content?
         # (will be discarded by importer)
@@ -201,12 +138,58 @@ class Parser(StoryWorker):
 
             cmd.parsed_date = dt.datetime.utcnow().isoformat()
 
-        hmd = story.http_metadata()
-        if hmd.final_url == NEED_CANONICAL_URL:
-            canonical_domain = self._check_canonical_domain(story, html)
-            if not canonical_domain:
-                return False  # logged and counted: discard
+        return True
 
+    def _extract_canonical_url(self, story: BaseStory) -> bool:
+        """
+        Here with story from Nov/Dec 2021, pulled from S3 without URL.
+        Some S3 objects are feeds, and cause loooong parse times (over
+        30 minutes), causing RabbitMQ to close connection, so try to
+        detect feeds, and extract canonical URL at the same time.
+        """
+        html_bytes = story.raw_html().html or b""
+        # XXX err if no content?
+
+        first = True
+        canonical_url = og_url = None
+        for event, element in iterparse(
+            io.BytesIO(html_bytes),
+            events=(
+                "start",
+                "end",
+            ),
+            recover=True,
+        ):
+            if first:
+                logger.debug("first tag %s", element.tag)
+                if element.tag in FEED_TAGS:
+                    self.incr_stories("feed", self._log_url(story))
+                    return False
+                first = False
+            if event == "end":
+                if element.tag == "head":
+                    break
+                if element.tag == "link":
+                    if not canonical_url and element.get("rel") == "canonical":
+                        canonical_url = element.get("href")
+                elif element.tag == "meta":
+                    if not og_url and element.get("property") == "og:url":
+                        og_url = element.get("content")
+        # end for event: prefer canonical_url
+        canonical_url = canonical_url or og_url
+        if not canonical_url:
+            self.incr_stories("no-canonical-url", self._log_url(story))
+            return False
+
+        logger.info("%s: canonical URL %s", story.rss_entry().link, canonical_url)
+
+        # now that we FINALLY have a URL, make sure it isn't
+        # from a source we filter out!!!
+        if not self.check_story_url(canonical_url):
+            return False
+
+        with story.http_metadata() as hmd:
+            hmd.final_url = canonical_url
         return True
 
     def process_story(self, sender: StorySender, story: BaseStory) -> None:
@@ -219,6 +202,10 @@ class Parser(StoryWorker):
         final_url = story.http_metadata().final_url
         if final_url is None:
             raise QuarantineException("no final_url")
+
+        if final_url == NEED_CANONICAL_URL:
+            if not self._extract_canonical_url(story):
+                return  # logged and counted
 
         try:
             mdd = mcmetadata.extract(final_url, html, stats_accumulator=extract_stats)


### PR DESCRIPTION
* If first tag look like a feed, immediately count & discard
* Else, scan to end head tag looking for canonical URL

(possible degenerate case: document that doesn't start with a "feed tag", and doesn't have a head section will parse entire document before discarding.  Does not try to handle errors: story will be requeued and then quarantined).

Takes < 1ms for either.  Tested on documents that take trafilatura and readability an hour of chewing (at 100% CPU) to come up empty.

Timing for one trouble document (read from WARC):
```
2024-10-27 17:55:37,998 | INFO | parser | parsing 3358172997: 9211438 characters
2024-10-27 17:55:38,320 | ERROR | htmldate.utils | parsed tree length: 1, wrong data type or not valid HTML
2024-10-27 17:55:38,621 | ERROR | trafilatura.utils | parsed tree length: 1, wrong data type or not valid HTML
2024-10-27 17:55:38,645 | ERROR | trafilatura.core | empty HTML tree for URL http://mediacloud.org/need_canonical_url
2024-10-27 17:55:38,674 | WARNING | trafilatura.core | discarding data for url: http://mediacloud.org/need_canonical_url
2024-10-27 18:14:37,467 | INFO | readability.readability | ruthless removal did not work. 
2024-10-27 18:52:17,758 | INFO | indexer.storyapp | feed: 3358172997
```

Here is the new code on a whole batch of stories left in queue (reading from same WARC file):
```
(venv) pbudne@bernstein:~/story-indexer$ ./bin/run-parser.sh --log-level debug --test-file-prefix parser-hang --rabbitmq-url x 
log: -t run-parser.sh -p debug invoking indexer.workers.parser --log-level debug --test-file-prefix parser-hang --rabbitmq-url x
2024-10-27 19:50:17,317 | INFO | indexer.app | STATSD_URL not set
2024-10-27 19:50:17,318 | INFO | indexer.sentry | SENTRY_DSN not found. Not logging errors to Sentry
2024-10-27 19:50:17,387 | DEBUG | indexer.app | encoding: 14.5822 ms
2024-10-27 19:50:17,388 | INFO | parser | parsing 3358172997: 9211438 characters
2024-10-27 19:50:17,388 | DEBUG | parser | encoding utf-8, was None
2024-10-27 19:50:17,388 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,388 | INFO | indexer.storyapp | feed: 3358172997
2024-10-27 19:50:17,441 | DEBUG | indexer.app | encoding: 15.3385 ms
2024-10-27 19:50:17,441 | INFO | parser | parsing 3357305750: 9216266 characters
2024-10-27 19:50:17,441 | DEBUG | parser | encoding utf-8, was None
2024-10-27 19:50:17,441 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,441 | INFO | indexer.storyapp | feed: 3357305750
2024-10-27 19:50:17,490 | DEBUG | indexer.app | encoding: 15.205 ms
2024-10-27 19:50:17,490 | INFO | parser | parsing 3357270854: 9209002 characters
2024-10-27 19:50:17,490 | DEBUG | parser | encoding utf-8, was None
2024-10-27 19:50:17,491 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,491 | INFO | indexer.storyapp | feed: 3357270854
2024-10-27 19:50:17,539 | DEBUG | indexer.app | encoding: 15.1761 ms
2024-10-27 19:50:17,539 | INFO | parser | parsing 3357170719: 9208027 characters
2024-10-27 19:50:17,539 | DEBUG | parser | encoding utf-8, was None
2024-10-27 19:50:17,541 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,541 | INFO | indexer.storyapp | feed: 3357170719
2024-10-27 19:50:17,565 | DEBUG | indexer.app | encoding: 1.38639 ms
2024-10-27 19:50:17,565 | INFO | parser | parsing 3356828136: 7785501 characters
2024-10-27 19:50:17,565 | DEBUG | parser | encoding iso-8859-1, was None
2024-10-27 19:50:17,566 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,566 | INFO | indexer.storyapp | feed: 3356828136
2024-10-27 19:50:17,615 | DEBUG | indexer.app | encoding: 17.4459 ms
2024-10-27 19:50:17,615 | INFO | parser | parsing 3356789661: 7233451 characters
2024-10-27 19:50:17,615 | DEBUG | parser | encoding utf-8, was None
2024-10-27 19:50:17,616 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,616 | INFO | indexer.storyapp | feed: 3356789661
2024-10-27 19:50:17,661 | DEBUG | indexer.app | encoding: 13.8607 ms
2024-10-27 19:50:17,661 | INFO | parser | parsing 3356670306: 7233058 characters
2024-10-27 19:50:17,661 | DEBUG | parser | encoding utf-8, was None
2024-10-27 19:50:17,661 | DEBUG | parser | first tag rss
2024-10-27 19:50:17,661 | INFO | indexer.storyapp | feed: 3356670306
2024-10-27 19:50:17,661 | INFO | indexer.storyapp | processed 7 stories
2024-10-27 19:50:17,662 | DEBUG | indexer.app | main_loop: 344.585 ms
log: -t run-parser.sh -p debug indexer.workers.parser --log-level debug --test-file-prefix parser-hang --rabbitmq-url x exit status 0
```