### PR TITLE
Set canonical_domain & Third try at using canonical URL from mcmetadata

### DIFF
--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -204,7 +204,7 @@ class Parser(StoryWorker):
         check if mcmetadata.extract found a canonical URL,
         validate it, and update Story object.
         """
-        log_url = self._log_url(story)
+        log_url = self._log_url(story)  # before setting final_url!!
 
         canonical_url = cmd.canonical_url
         if not canonical_url or canonical_url == NEED_CANONICAL_URL:
@@ -215,8 +215,6 @@ class Parser(StoryWorker):
         # from a source we filter out!!!
         if not self.check_story_url(canonical_url):
             return False  # logged and counted
-
-        log_url = self._log_url(story)  # before setting final_url!!
 
         with story.http_metadata() as hmd:
             # story_archive_writer wants hmd.final_url


### PR DESCRIPTION
The second (to try avoid HTML parser slowness, and extract canonical URL up front) performed worse (fewer stories extracted) than original.

This uses XMLPullParser to detect/discard feed documents by looking at the first tag only (no canonical URL extraction, it was too painful having two places that might supply it).

With apples to apples comparison (runs with same CSV of 100K objects, note: staging runs on a random sampling of 50K) created EXACTLY the same number of stories in ES as original version.