### PR TITLE
More ES stats, extract RSS file header date

### DIFF
--- a/indexer/scripts/elastic-stats.py
+++ b/indexer/scripts/elastic-stats.py
@@ -149,6 +149,33 @@ class ElasticStats(ElasticMixin, IntervalMixin, App):
         ]:
             self.g(f"cluster.health.pending_tasks.{short}", cluster_health[attr])
 
+    def cat_nodes(self) -> None:
+        """
+        Docs say:
+
+        cat (Compact and aligned text) APIs are only intended for
+        human consumption using the Kibana console or command
+        line. They are not intended for use by applications. For
+        application consumption, we recommend using a corresponding
+        JSON API.
+
+        BUT I can't find the CPU/loadvg data elsewere, and while CPU% and
+        loadavg info is available on a per-server basis (by server name)
+        not by stack name / realm.
+        """
+
+        es = self.elasticsearch_client()
+        nodes = cast(list[dict[str, Any]], es.cat.nodes(format="json").raw)
+        keys = ["cpu", "load_1m", "load_5m", "load_15m"]
+        for node in nodes:
+            name = node["name"].split(".")[0]
+            labels = [("node", name)]
+            for key in keys:
+                try:
+                    self.g(f"cat.nodes.{key}", node[key], labels=labels)
+                except KeyError:
+                    pass
+
     def main_loop(self) -> None:
         while True:
             try:
@@ -165,6 +192,11 @@ class ElasticStats(ElasticMixin, IntervalMixin, App):
                 self.cluster_health()
             except (ConnectionError, ConnectionTimeout, KeyError) as e:
                 logger.warning("cluster.health: %r", e)
+
+            try:
+                self.cat_nodes()
+            except (ConnectionError, ConnectionTimeout, KeyError) as e:
+                logger.warning("cat.nodes: %r", e)
 
             # sleep until top of next period:
             self.interval_sleep()

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -121,6 +121,18 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
         data: dict[str, Optional[Union[str, bool]]] = {}
         # extract valid keys from index template (schema)
 
+        fetch_ts = story.http_metadata().fetch_timestamp
+        if fetch_ts:
+            # Here with timestamp of when story was fetched, make
+            # visible to see what's currently entering ES.
+            # While it's tempting to subtract off the current time (to
+            # get an idea of "how far behind" we are, with
+            # historical data from S3 fetch_timestamp will be the
+            # original fetch time (and historical data is processed
+            # from newest to oldest, so send in as ms (displayable
+            # in Grafana as "Date & Time")
+            self.timing("fetch-ts", fetch_ts * 1000.0)
+
         self.incr("field_check.stories")  # total number of stories checked
         for key, value in content_metadata.as_dict().items():
             if key in self.elasticsearch_fields:

--- a/indexer/workers/parser.py
+++ b/indexer/workers/parser.py
@@ -261,7 +261,9 @@ class Parser(StoryWorker):
 
         # change datetime object to JSON-safe string
         if mdd["publication_date"] is not None:
-            pub_date = mdd["publication_date"].strftime("%Y-%m-%d")
+            pub_dt = mdd["publication_date"]
+            pub_date = pub_dt.strftime("%Y-%m-%d")
+            self.timing("extracted-pub-date", pub_dt.date())
         else:
             pub_date = None
         mdd["publication_date"] = pub_date


### PR DESCRIPTION
1. Report per ES server CPU utilization in ES stats (for Elasticsearch Graphs dashboard)
2. parser reports extracted published_date as a timer (only upper/lower are useful) to get a peek at what's being processed.
3. importer reports fetch_timestamp as a timer (again only upper/lower as useful) to see how long processing takes
4. When queuing RSS files (only used for dev/staging) use RSS "last published date" in header for rss_entry fetch_date