### PR TITLE
Pass an client-unique "opaque_id" to Elasticsearch

### DIFF
--- a/indexer/app.py
+++ b/indexer/app.py
@@ -42,6 +42,8 @@ class AppProtocol(Protocol):
 
     args: Optional[argparse.Namespace]
 
+    process_name: str
+
     def define_options(self, ap: argparse.ArgumentParser) -> None: ...
 
     def process_args(self) -> None: ...


### PR DESCRIPTION
Visible in ES tasks API (for example my "top-queries" program): helps identify what process in what stack made the connection

