### PR TITLE
Add importer --no-import / deploy -z option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docker/config.json
 docker/deploy.log
 docker/docker-compose.yml
 docker/docker-compose.yml.dump
+docker/docker-compose.yml.save-*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# pull official base image
-FROM python:3.10-slim-bookworm as builder
+# pull python official base image
+FROM python:3.10-slim-bookworm AS builder
 
 # set work directory
 WORKDIR /app

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -731,8 +731,10 @@ mv -f docker-compose.yml.new docker-compose.yml
 chmod -w docker-compose.yml
 
 echo "checking docker-compose.yml syntax" 1>&2
-rm -f docker-compose.yml.dump
-docker stack config -c docker-compose.yml > docker-compose.yml.dump
+# was .dump; save using TAG for reference
+DUMPFILE=docker-compose.yml.save-$TAG
+rm -f $DUMPFILE
+docker stack config -c docker-compose.yml > $DUMPFILE
 STATUS=$?
 if [ $STATUS != 0 ]; then
     echo "docker stack config status: $STATUS" 1>&2
@@ -744,7 +746,7 @@ if [ $STATUS != 0 ]; then
     fi
 else
     # maybe only keep if $DEBUG set??
-    echo "output (with merges expanded) in docker-compose.yml.dump" 1>&2
+    echo "output (with merges expanded) in $DUMPFILE" 1>&2
 fi
 
 # XXX check if on suitable server (right swarm?) for prod/staging??

--- a/docker/docker-compose.yml.j2
+++ b/docker/docker-compose.yml.j2
@@ -22,9 +22,9 @@
  # has explicitly NOT been passed as a value to this template
  # to discourage decision-making here!
 -#}
-version: "3.8"
 # https://docs.docker.com/compose/compose-file/compose-file-v3/
 # https://github.com/compose-spec/compose-spec/blob/master/spec.md
+# removed version tag to silence deprecation messages.
 {#
  # The compose-file-v3 spec above says the following options are
  # ignored with "docker stack deploy" in swarm mode: cap_add,

--- a/indexer/workers/importer.py
+++ b/indexer/workers/importer.py
@@ -91,7 +91,7 @@ class ElasticsearchImporter(ElasticConfMixin, StoryWorker):
         self.no_import = self.args.no_import
 
         if not self.output_msgs and self.no_import:
-            logger.error("no output AND no import?!")
+            logger.warning("no output AND no import?!")
 
         index_template = self.load_index_template()
         if not index_template:


### PR DESCRIPTION
This is to enable "off-line" processing of historical data, direct to the (B2) archive, so that the 2022 (csv) "dip" period can be re-run using blind fetching from S3 with canonical URL extraction before possibly removing the old stories from the index.

Also silences complaints about Dockerfile, stack deploy command & docker-compose.yml

Preserves expanded docker-compose.yml.dump files as docker-compose.yml.save-TAG