### PR TITLE
Add ability to remove archive documents from ElasticSearch using original URL 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docker/deploy.log
 docker/docker-compose.yml
 docker/docker-compose.yml.dump
 docker/docker-compose.yml.save-*
+*.sqlite3

--- a/bin/run-arch-eraser.sh
+++ b/bin/run-arch-eraser.sh
@@ -24,7 +24,7 @@ increment_date() {
     esac
 }
 
-if [ $# -ne 3 ]; then
+if [ $# -lt 3 ]; then
     echo "Usage: $0 [start_date] [end_date] [pattern]" >&2
     exit 1
 fi
@@ -32,6 +32,8 @@ fi
 start_date="$1"
 end_date="$2"
 pattern="$3"
+shift 3
+other_params="$*"
 
 if ! is_valid_date "$start_date" || ! is_valid_date "$end_date"; then
     echo "Error: Invalid date format. Use YYYY/MM/DD" >&2
@@ -50,7 +52,7 @@ convert_date_to_int() {
     fi
 }
 
-output_string="--rabbitmq-url='-' "
+output_string=""
 start_date_int=$(convert_date_to_int "$start_date")
 end_date_int=$(convert_date_to_int "$end_date")
 
@@ -61,4 +63,4 @@ while [ "$start_date_int" -le "$end_date_int" ]; do
     start_date_int=$(convert_date_to_int "$start_date")
 done
 
-run_python indexer.scripts.arch-eraser $output_string
+run_python indexer.scripts.arch-eraser ${output_string} ${other_params}

--- a/bin/run-arch-eraser.sh
+++ b/bin/run-arch-eraser.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+. bin/func.sh
+
+is_valid_date() {
+    case "$1" in
+        [0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+increment_date() {
+    date_cmd=$(command -v date)
+    case "$(uname)" in
+        Darwin)
+            "$date_cmd" -j -v+1d -f "%Y/%m/%d" "$1" +"%Y/%m/%d"
+            ;;
+        Linux)
+            "$date_cmd" -d "$1 + 1 day" +"%Y/%m/%d" 2>/dev/null
+            ;;
+        *)
+            echo "Unsupported Environment" >&2
+            return 1
+            ;;
+    esac
+}
+
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 [start_date] [end_date] [pattern]" >&2
+    exit 1
+fi
+
+start_date="$1"
+end_date="$2"
+pattern="$3"
+
+if ! is_valid_date "$start_date" || ! is_valid_date "$end_date"; then
+    echo "Error: Invalid date format. Use YYYY/MM/DD" >&2
+    exit 1
+fi
+
+convert_date_to_int() {
+    input_date="$1"
+    if [ "$(uname)" = "Darwin" ]; then
+        date -j -f "%Y/%m/%d" "$input_date" +"%Y%m%d" 2>/dev/null
+    elif [ "$(uname)" = "Linux" ]; then
+        date -d "$input_date" +"%Y%m%d" 2>/dev/null
+    else
+        echo "Unsupported OS" >&2
+        return 1
+    fi
+}
+
+output_string="--rabbitmq-url='-' "
+start_date_int=$(convert_date_to_int "$start_date")
+end_date_int=$(convert_date_to_int "$end_date")
+
+while [ "$start_date_int" -le "$end_date_int" ]; do
+    current_url=$(echo "$pattern" | sed "s|{pattern}|$start_date|g")
+    output_string="${output_string}${current_url} "
+    start_date=$(increment_date "$start_date")
+    start_date_int=$(convert_date_to_int "$start_date")
+done
+
+run_python indexer.scripts.arch-eraser $output_string

--- a/indexer/elastic.py
+++ b/indexer/elastic.py
@@ -66,7 +66,7 @@ class ElasticMixin(AppProtocol):
         if not self.elasticsearch_hosts:
             logger.fatal("need --elasticsearch-hosts or ELASTICSEARCH_HOSTS")
             sys.exit(1)
-
+        print(self.elasticsearch_hosts)
         # Connects immediately, performs failover and retries
         return Elasticsearch(
             self.elasticsearch_hosts.split(","), opaque_id=self.opaque_id

--- a/indexer/queuer.py
+++ b/indexer/queuer.py
@@ -212,6 +212,17 @@ class Queuer(ShufflingStoryProducer):
         args = self.args
         assert args
 
+        if fname[0] == "@":
+            # implement "indirect file" (file containing file names)
+            # NOTE! paths read from indirect files are NOT interpreted
+            # as relative to the path of the indirect file.
+            logger.info("indirect file %s", fname)
+
+            f = self.open_file(fname[1:])
+            for line in f:
+                self.maybe_process_file(line.decode().rstrip())
+            return
+
         if args.test:
             logger.info("maybe_process_file %s", fname)
             return

--- a/indexer/scripts/arch-eraser.py
+++ b/indexer/scripts/arch-eraser.py
@@ -25,48 +25,39 @@ with some available from B2 as well (may be cheaper to fetch from B2).
 
 2. From RSS files blindly extracted from S3 (ignoring the HTML files!) into CSV files of URLs
 
-================ index mc_search-00002 created 2024-03-24T01:07:19.076Z
+Stories in index mc_search-00002 and mc_search-00003
 
 All files on S3, some on B2 (starting 2024/05/31)
 
 arch prefix     start           end             archives
-mccsv           2024/05/22 -> 2024/06/22        S3/(B2)
-mc[rss]         2024/05/27 -> 2024/06/22        S3/(B2) [1]
+mccsv           2024/05/22 -> 2024/06/27        S3/(B2)
+mc(rss)         2024/05/27 -> 2024/06/20        S3/(B2) [1]
+mcrss           2024/06/20 -> 2024/08/16        S3/B2
 
 (B2) means some of the date range on B2
 
-[1] files named mcrss- start 2024/06/20.
-    files written from 2024/05/27 thru 2024/06/20 start with mc-
-    (see below):
+[1] initial WARC files from RSS files written from 2024/05/27 thru
+    2024/06/20 start with mc- (see below):
 
     THESE SHOULD BE VERIFIED!!! The "via" field in the metadata
     should indicate how the URL was obtained!
 
     dates                   container name (in WARC filename)
-    2024/05/27-2024/05/28   cf94b52abe5a
-    2024/05/29-2024/06/04   cefd3fdce464
-    2024/06/05              0c501ed61cf4
-    2024/06/05              446d55936e82
+    2024/05/27-2024/05/28   cf94b52abe5a        S3 [154 files]
+    2024/05/29-2024/06/04   cefd3fdce464        S3 [882 files]
+    2024/06/05              0c501ed61cf4        S3 & B2 [497 files]
+    2024/06/05              446d55936e82        S3 & B2 [27 files]
     2024/06/05              cefd3fdce464
     2024/06/06-2024/06/09   0c501ed61cf4
-    2024/06/09              7e1b47c305f1
+    2024/06/09              7e1b47c305f1        S3 & B2 [1 file]
     2024/06/11-2024/06/20   6c55aaf9daaa
-
-================ mc_search-000003 created 2024-06-22T01:09:36.337Z
-
-arch prefix     start           end             archives
-mccsv           2024/06/22 -> 2024/06/27        S3/(B2)
-mcrss           2024/06/22 -> 2024/08/16        S3/(B2)
-
-(B2) means some of the date range on B2
-(S3) means some of the date range on S3
 
 ================
 
 This is based on the "Queuer" class, which reads both local and remote
 input files, and keeps track of which files have been processed.
 
-No queues are involved, so this code should be runnable outside of Docker.
+No queues are involved (provide any value for --rabbitmq-url or RABBITMQ_URL)
 
 The "tracker" uses SQLite3 (**), and should be multi-process safe,
 although this application may experience more contention (SQLite3 does

--- a/indexer/scripts/arch-eraser.py
+++ b/indexer/scripts/arch-eraser.py
@@ -1,0 +1,128 @@
+"""
+Sketch of an "archive eraser"
+
+Reads archive files (possibly from remote "blob stores"), extracts URLs
+and removes objects from Elasticsearch.
+
+NOTE!! Does not actually remove the archive files from their
+off-site storage location(s)!!!!
+
+This was written to remove stories for late Jan thru early March 2022
+(database E) that were initially recovered in 2024 (with some link
+rot) thru various means(*), so that stories "blindly" recovered from
+S3 (without known URL) where canonical URLs were then extracted.
+
+However, experimention suggested that loading the canonical URLs
+without first removing the first attempt could lead to a 10% duplicate
+rate (initial vs. final URLs and other URL differences).
+
+From the below, it appears all of the WARC files are available on S3,
+with some available from B2 as well (may be cheaper to fetch from B2).
+
+(*) The different ways the URLs were recovered:
+1. From synthetic RSS files written at the time for IA (both by the legacy system
+   and the then "backup" rss-fetcher.
+
+2. From RSS files blindly extracted from S3 (ignoring the HTML files!) into CSV files of URLs
+
+================ index mc_search-00002 created 2024-03-24T01:07:19.076Z
+
+All files on S3, some on B2 (starting 2024/05/31)
+
+arch prefix     start           end             archives
+mccsv           2024/05/22 -> 2024/06/22        S3/(B2)
+mc[rss]         2024/05/27 -> 2024/06/22        S3/(B2) [1]
+
+(B2) means some of the date range on B2
+
+[1] files named mcrss- start 2024/06/20.
+    files written from 2024/05/27 thru 2024/06/20 start with mc-
+    (see below):
+
+    THESE SHOULD BE VERIFIED!!! The "via" field in the metadata
+    should indicate how the URL was obtained!
+
+    dates                   container name (in WARC filename)
+    2024/05/27-2024/05/28   cf94b52abe5a
+    2024/05/29-2024/06/04   cefd3fdce464
+    2024/06/05              0c501ed61cf4
+    2024/06/05              446d55936e82
+    2024/06/05              cefd3fdce464
+    2024/06/06-2024/06/09   0c501ed61cf4
+    2024/06/09              7e1b47c305f1
+    2024/06/11-2024/06/20   6c55aaf9daaa
+
+================ mc_search-000003 created 2024-06-22T01:09:36.337Z
+
+arch prefix     start           end             archives
+mccsv           2024/06/22 -> 2024/06/27        S3/(B2)
+mcrss           2024/06/22 -> 2024/08/16        S3/(B2)
+
+(B2) means some of the date range on B2
+(S3) means some of the date range on S3
+
+================
+
+This is based on the "Queuer" class, which reads both local and remote
+input files, and keeps track of which files have been processed.
+
+No queues are involved, so this code should be runnable outside of Docker.
+
+The "tracker" uses SQLite3 (**), and should be multi-process safe,
+although this application may experience more contention (SQLite3 does
+full-table locks for row creation), and testing should be done (using
+--dry-run) with multiple processes running to see if any errors or
+exceptions are thrown due to lock contention!
+
+(**) The author doesn't care how you pronounce it, but he says "ess cue ell ite"
+(like it's a mineral): https://www.youtube.com/watch?v=Jib2AmRb_rk
+
+Because the files involved span a wide range of dates, and have
+various forms, rather than implement fancy wildcard or filtering
+support, the idea is to collect all the (full) archive URLs into a
+file (or files), and use the "indirect file" feature in the queuer
+to read the files of URLs.
+"""
+
+import logging
+from typing import BinaryIO
+
+from indexer.queuer import Queuer
+from indexer.story_archive_writer import StoryArchiveReader
+
+logger = logging.getLogger("arch-eraser")
+
+
+class ArchEraser(Queuer):
+    APP_BLOBSTORE = "HIST"  # first choice for blobstore conf vars
+    HANDLE_GZIP = False  # StoryArchiveReader handles compression
+
+    # don't want to talk to RabbitMQ, but too much work
+    # to refactor Queuer into a FileProcessor add-in
+
+    def qconnect(self) -> None:
+        return
+
+    def check_output_queues(self) -> None:
+        return
+
+    def process_file(self, fname: str, fobj: BinaryIO) -> None:
+        assert self.args
+
+        logger.info("process_file %s", fname)
+
+        # it may be possible to make this faster by NOT using
+        # StoryArchiveReader and warcio, but it came for "free":
+        reader = StoryArchiveReader(fobj)
+        urls = []
+        for story in reader.read_stories():
+            urls.append(story.content_metadata().url)
+
+        logger.info("collected %d urls from %s", len(urls), fname)
+        if not self.args.dry_run:
+            logger.warning("delete %d urls from %s here!", len(urls), fname)
+
+
+if __name__ == "__main__":
+    app = ArchEraser("arch-eraser", "remove stories loaded from archive files from ES")
+    app.main()


### PR DESCRIPTION
This PR modifies the [Arch Eraser](https://github.com/philbudne/story-indexer/blob/arch-eraser-sketch/indexer/scripts/arch-eraser.py) sketch to allow the deletion of archived documents from ElasticSearch.

The python script can be invoked as

```
 python arch-eraser.py b2://mediacloud-indexer-archive/2024/12/14/mchist2022-20241214235742-291-9d4ffe800d4a.warc.gz --rabbitmq-url="-" --elasticsearch-hosts="http://localhost:9200" --indices="mc_search-000001"
```


Since the documents are stored with a certain  prefix (hist2022) within a specified date as discussed [here](https://github.com/mediacloud/story-indexer/issues/353#issuecomment-2593349155) the PR includes a bash script that generates a pattern that can be used to match documents with a certain remote URL pattern to ease how we invoke the arch-eraser.  This script can be executed using the following format:
```
./bin/run-arch-eraser.sh <START_DATE> <END_DATE> <REMOTE_URL> '<OTHER OPTIONS>'
```
Example:
```
./bin/run-arch-eraser.sh 2024/12/14 2024/12/16 "b2://mediacloud-indexer-archive/{pattern}/mchist2022" '--rabbitmq-url="-"  --elasticsearch-hosts=http://localhost:9200  --indices=mc_search-000001' 
```

Will append: `b2://mediacloud-indexer-archive/2024/12/14/mchist2022 b2://mediacloud-indexer-archive/2024/12/15/mchist2022 b2://mediacloud-indexer-archive/2024/12/16/mchist2022` as args when we invoke the arch-eraser script.

The script supports both bulk and individual record removal from Elasticsearch. I tested it on my local Elasticsearch instance with approximately 500,000 documents, removing URLs extracted from 50 WARC files containing around 250,000 records. Over 10 iterations of the same task, the following average time was observed:
- Bulk deletion: 11.55 seconds
- Individual records deletion : 271.09 seconds
