### PR TITLE
Have hist-queuer discard rows without downloads_id

### DIFF
--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -85,7 +85,7 @@ class HistQueuer(Queuer):
                 url = NEED_CANONICAL_URL
 
             dlid = row.get("downloads_id")  # REQUIRED
-            if not dlid or not isinstance(dlid, str) or not dlid.isdigit():
+            if not dlid or not dlid.isdigit():
                 self.incr_stories("bad-dlid", url)
                 continue
 

--- a/indexer/workers/hist-queuer.py
+++ b/indexer/workers/hist-queuer.py
@@ -84,8 +84,10 @@ class HistQueuer(Queuer):
             else:
                 url = NEED_CANONICAL_URL
 
-            dlid = row.get("downloads_id")
-            # let hist-fetcher quarantine if bad
+            dlid = row.get("downloads_id")  # REQUIRED
+            if not dlid or not isinstance(dlid, str) or not dlid.isdigit():
+                self.incr_stories("bad-dlid", url)
+                continue
 
             # convert to int: OK if missing or malformed
             try:


### PR DESCRIPTION
Currently passing everything thru to hist-fetcher, which quarantines them.

Did not change hist-fetcher; It's now reasonable to quarantine stories which should never have gotten there!