### PR TITLE
Update pyproject.toml to specify elasticsearch client 8.17.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: http://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,22 +11,22 @@ repos:
       - id: check-json
       - id: check-toml
   - repo: http://github.com/ambv/black
-    rev: 24.10.0
+    rev: 25.11.0
     hooks:
       - id: black
         language_version: python3.10
   - repo: http://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.0
+    rev: v1.18.2
     hooks:
       - id: mypy
         entry: bin/pre-commit-wrapper.py mypy
         additional_dependencies: ["pip==22.0.*"]
   - repo: http://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: http://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 7.0.0
     hooks:
       - id: isort
         name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "beautifulsoup4 ~= 4.12.2",
   "boto3 ~= 1.28.44",
   "docker ~= 7.1.0",
-  "elasticsearch ~= 8.12.0",
+  "elasticsearch ~= 8.17.2",
   # lxml installed by some other package?
   "mediacloud-metadata ~= 1.4.1",
   "pika ~= 1.3.2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,13 +6,13 @@
 #
 annotated-types==0.7.0
     # via pydantic
-attrs==24.3.0
+attrs==25.4.0
     # via
     #   service-identity
     #   twisted
-automat==24.8.1
+automat==25.4.16
     # via twisted
-babel==2.16.0
+babel==2.17.0
     # via courlan
 beautifulsoup4==4.12.3
     # via
@@ -31,72 +31,72 @@ botocore==1.31.85
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.35.86
+botocore-stubs==1.40.71
     # via boto3-stubs
-certifi==2024.12.14
+certifi==2025.10.5
     # via
     #   elastic-transport
     #   requests
     #   sentry-sdk
     #   trafilatura
-cffi==1.17.1
+cffi==2.0.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via readability-lxml
-charset-normalizer==3.4.0
+charset-normalizer==3.4.4
     # via
     #   htmldate
     #   requests
     #   trafilatura
-click==8.1.8
+click==8.3.0
     # via nltk
 constantly==23.10.4
     # via twisted
 courlan==1.3.2
     # via trafilatura
-cryptography==44.0.0
+cryptography==46.0.3
     # via
     #   pyopenssl
     #   scrapy
     #   service-identity
-cssselect==1.2.0
+cssselect==1.3.0
     # via
     #   goose3
     #   newspaper3k
     #   parsel
     #   readability-lxml
     #   scrapy
-dateparser==1.2.0
+dateparser==1.2.2
     # via
     #   htmldate
     #   mediacloud-metadata
 defusedxml==0.7.1
     # via scrapy
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 docker==7.1.0
     # via story-indexer (pyproject.toml)
-elastic-transport==8.15.1
+elastic-transport==8.17.1
     # via elasticsearch
-elasticsearch==8.12.1
+elasticsearch==8.17.2
     # via story-indexer (pyproject.toml)
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via pytest
 faust-cchardet==2.1.19
     # via mediacloud-metadata
 feedfinder2==0.0.4
     # via newspaper3k
-feedparser==6.0.11
+feedparser==6.0.12
     # via newspaper3k
-filelock==3.16.1
+filelock==3.20.0
     # via
     #   tldextract
     #   virtualenv
-furl==2.1.3
+furl==2.1.4
     # via mediacloud-metadata
-goose3==3.1.19
+goose3==3.1.20
     # via mediacloud-metadata
 htmldate==1.8.1
     # via
@@ -104,9 +104,9 @@ htmldate==1.8.1
     #   trafilatura
 hyperlink==21.0.0
     # via twisted
-identify==2.6.3
+identify==2.6.15
     # via pre-commit
-idna==3.10
+idna==3.11
     # via
     #   hyperlink
     #   requests
@@ -115,9 +115,9 @@ incremental==24.7.2
     # via twisted
 inflection==0.5.1
     # via pyairtable
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
-itemadapter==0.10.0
+itemadapter==0.12.2
     # via
     #   itemloaders
     #   scrapy
@@ -125,7 +125,7 @@ itemloaders==1.3.2
     # via scrapy
 jieba3k==0.35.1
     # via newspaper3k
-jinja2==3.1.5
+jinja2==3.1.6
     # via jinja2-cli
 jinja2-cli==0.8.2
     # via story-indexer (pyproject.toml)
@@ -135,9 +135,9 @@ jmespath==1.0.1
     #   botocore
     #   itemloaders
     #   parsel
-joblib==1.4.2
+joblib==1.5.2
     # via nltk
-justext==3.0.1
+justext==3.0.2
     # via trafilatura
 langdetect==1.0.9
     # via goose3
@@ -146,14 +146,17 @@ lxml==5.1.1
     #   goose3
     #   htmldate
     #   justext
+    #   lxml-html-clean
     #   newspaper3k
     #   parsel
     #   readability-lxml
     #   scrapy
     #   trafilatura
+lxml-html-clean==0.4.3
+    # via readability-lxml
 lxml-stubs==0.5.1
     # via story-indexer (pyproject.toml)
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
     # via story-indexer (pyproject.toml)
@@ -163,44 +166,44 @@ mypy==1.5.1
     # via story-indexer (pyproject.toml)
 mypy-boto3-s3==1.34.162
     # via boto3-stubs
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
 newspaper3k==0.2.8
     # via mediacloud-metadata
-nltk==3.9.1
+nltk==3.9.2
     # via newspaper3k
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.2.1
+numpy==2.2.6
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
-packaging==24.2
+packaging==25.0
     # via
     #   parsel
     #   pytest
     #   scrapy
-parsel==1.9.1
+parsel==1.10.0
     # via
     #   itemloaders
     #   scrapy
 pika==1.3.2
     # via story-indexer (pyproject.toml)
-pillow==11.0.0
+pillow==12.0.0
     # via
     #   goose3
     #   newspaper3k
-platformdirs==4.3.6
+platformdirs==4.5.0
     # via virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pre-commit==3.4.0
     # via story-indexer (pyproject.toml)
-protego==0.3.1
+protego==0.5.0
     # via scrapy
 py3langid==0.2.2
     # via mediacloud-metadata
-pyahocorasick==2.1.0
+pyahocorasick==2.2.0
     # via goose3
 pyairtable==2.3.7
     # via
@@ -210,17 +213,17 @@ pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   service-identity
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via service-identity
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pydantic==2.10.4
+pydantic==2.12.4
     # via pyairtable
-pydantic-core==2.27.2
+pydantic-core==2.41.5
     # via pydantic
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==24.3.0
+pyopenssl==25.3.0
     # via scrapy
 pytest==7.4.4
     # via story-indexer (pyproject.toml)
@@ -231,23 +234,23 @@ python-dateutil==2.9.0.post0
     #   goose3
     #   htmldate
     #   newspaper3k
-pytz==2024.2
+pytz==2025.2
     # via dateparser
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   newspaper3k
     #   pre-commit
-queuelib==1.7.0
+queuelib==1.8.0
     # via scrapy
 rabbitmq-admin==0.2
     # via story-indexer (pyproject.toml)
-readability-lxml==0.8.1
+readability-lxml==0.8.4.1
     # via mediacloud-metadata
-regex==2024.11.6
+regex==2025.11.3
     # via
     #   dateparser
     #   nltk
-requests==2.32.3
+requests==2.32.5
     # via
     #   docker
     #   feedfinder2
@@ -258,7 +261,7 @@ requests==2.32.3
     #   rabbitmq-admin
     #   requests-file
     #   tldextract
-requests-file==2.1.0
+requests-file==3.0.1
     # via tldextract
 s3transfer==0.7.0
     # via boto3
@@ -281,7 +284,7 @@ six==1.17.0
     #   surt
     #   url-normalize
     #   warcio
-soupsieve==2.6
+soupsieve==2.8
     # via beautifulsoup4
 statsd-client==1.0.7
     # via story-indexer (pyproject.toml)
@@ -291,7 +294,7 @@ surt==0.3.1
     # via mediacloud-metadata
 tinysegmenter==0.3
     # via newspaper3k
-tld==0.13
+tld==0.13.1
     # via courlan
 tldextract==5.1.3
     # via
@@ -299,7 +302,7 @@ tldextract==5.1.3
     #   newspaper3k
     #   scrapy
     #   surt
-tomli==2.2.1
+tomli==2.3.0
     # via
     #   incremental
     #   mypy
@@ -308,30 +311,37 @@ tqdm==4.67.1
     # via nltk
 trafilatura==1.8.1
     # via mediacloud-metadata
-twisted==24.11.0
+twisted==25.5.0
     # via scrapy
-types-awscrt==0.23.6
+types-awscrt==0.28.4
     # via botocore-stubs
-types-beautifulsoup4==4.12.0.20241020
+types-beautifulsoup4==4.12.0.20250516
     # via story-indexer (pyproject.toml)
-types-html5lib==1.1.11.20241018
+types-html5lib==1.1.11.20251014
     # via types-beautifulsoup4
 types-pika==1.2.0b1
     # via story-indexer (pyproject.toml)
 types-requests==2.31.0.20240406
     # via story-indexer (pyproject.toml)
-types-s3transfer==0.10.4
+types-s3transfer==0.14.0
     # via boto3-stubs
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   boto3-stubs
+    #   cryptography
+    #   exceptiongroup
     #   mypy
     #   mypy-boto3-s3
     #   pyairtable
     #   pydantic
     #   pydantic-core
+    #   pyopenssl
     #   twisted
-tzlocal==5.2
+    #   typing-inspection
+    #   virtualenv
+typing-inspection==0.4.2
+    # via pydantic
+tzlocal==5.3.1
     # via dateparser
 url-normalize==1.4.3
     # via mediacloud-metadata
@@ -347,23 +357,22 @@ urllib3==2.0.7
     #   sentry-sdk
     #   trafilatura
     #   types-requests
-virtualenv==20.28.0
+virtualenv==20.35.4
     # via pre-commit
-w3lib==2.2.1
+w3lib==2.3.1
     # via
     #   parsel
     #   scrapy
 warcio==1.7.5
     # via story-indexer (pyproject.toml)
-zope-interface==7.2
+zope-interface==8.1
     # via
     #   scrapy
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.6.0
+setuptools==80.9.0
     # via
     #   incremental
     #   scrapy
     #   supervisor
-    #   zope-interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --allow-unsafe --strip-extras pyproject.toml
 #
-attrs==24.3.0
+attrs==25.4.0
     # via
     #   service-identity
     #   twisted
-automat==24.8.1
+automat==25.4.16
     # via twisted
-babel==2.16.0
+babel==2.17.0
     # via courlan
 beautifulsoup4==4.12.3
     # via
@@ -27,40 +27,40 @@ botocore==1.31.85
     # via
     #   boto3
     #   s3transfer
-certifi==2024.12.14
+certifi==2025.10.5
     # via
     #   elastic-transport
     #   requests
     #   sentry-sdk
     #   trafilatura
-cffi==1.17.1
+cffi==2.0.0
     # via cryptography
 chardet==5.2.0
     # via readability-lxml
-charset-normalizer==3.4.0
+charset-normalizer==3.4.4
     # via
     #   htmldate
     #   requests
     #   trafilatura
-click==8.1.8
+click==8.3.0
     # via nltk
 constantly==23.10.4
     # via twisted
 courlan==1.3.2
     # via trafilatura
-cryptography==44.0.0
+cryptography==46.0.3
     # via
     #   pyopenssl
     #   scrapy
     #   service-identity
-cssselect==1.2.0
+cssselect==1.3.0
     # via
     #   goose3
     #   newspaper3k
     #   parsel
     #   readability-lxml
     #   scrapy
-dateparser==1.2.0
+dateparser==1.2.2
     # via
     #   htmldate
     #   mediacloud-metadata
@@ -68,21 +68,21 @@ defusedxml==0.7.1
     # via scrapy
 docker==7.1.0
     # via story-indexer (pyproject.toml)
-elastic-transport==8.15.1
+elastic-transport==8.17.1
     # via elasticsearch
-elasticsearch==8.12.1
+elasticsearch==8.17.2
     # via story-indexer (pyproject.toml)
 faust-cchardet==2.1.19
     # via mediacloud-metadata
 feedfinder2==0.0.4
     # via newspaper3k
-feedparser==6.0.11
+feedparser==6.0.12
     # via newspaper3k
-filelock==3.16.1
+filelock==3.20.0
     # via tldextract
-furl==2.1.3
+furl==2.1.4
     # via mediacloud-metadata
-goose3==3.1.19
+goose3==3.1.20
     # via mediacloud-metadata
 htmldate==1.8.1
     # via
@@ -90,14 +90,14 @@ htmldate==1.8.1
     #   trafilatura
 hyperlink==21.0.0
     # via twisted
-idna==3.10
+idna==3.11
     # via
     #   hyperlink
     #   requests
     #   tldextract
 incremental==24.7.2
     # via twisted
-itemadapter==0.10.0
+itemadapter==0.12.2
     # via
     #   itemloaders
     #   scrapy
@@ -111,9 +111,9 @@ jmespath==1.0.1
     #   botocore
     #   itemloaders
     #   parsel
-joblib==1.4.2
+joblib==1.5.2
     # via nltk
-justext==3.0.1
+justext==3.0.2
     # via trafilatura
 langdetect==1.0.9
     # via goose3
@@ -122,52 +122,55 @@ lxml==5.1.1
     #   goose3
     #   htmldate
     #   justext
+    #   lxml-html-clean
     #   newspaper3k
     #   parsel
     #   readability-lxml
     #   scrapy
     #   trafilatura
+lxml-html-clean==0.4.3
+    # via readability-lxml
 mediacloud-metadata==1.4.1
     # via story-indexer (pyproject.toml)
 newspaper3k==0.2.8
     # via mediacloud-metadata
-nltk==3.9.1
+nltk==3.9.2
     # via newspaper3k
-numpy==2.2.1
+numpy==2.2.6
     # via py3langid
 orderedmultidict==1.0.1
     # via furl
-packaging==24.2
+packaging==25.0
     # via
     #   parsel
     #   scrapy
-parsel==1.9.1
+parsel==1.10.0
     # via
     #   itemloaders
     #   scrapy
 pika==1.3.2
     # via story-indexer (pyproject.toml)
-pillow==11.0.0
+pillow==12.0.0
     # via
     #   goose3
     #   newspaper3k
-protego==0.3.1
+protego==0.5.0
     # via scrapy
 py3langid==0.2.2
     # via mediacloud-metadata
-pyahocorasick==2.1.0
+pyahocorasick==2.2.0
     # via goose3
 pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   service-identity
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via service-identity
-pycparser==2.22
+pycparser==2.23
     # via cffi
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==24.3.0
+pyopenssl==25.3.0
     # via scrapy
 python-dateutil==2.9.0.post0
     # via
@@ -176,21 +179,21 @@ python-dateutil==2.9.0.post0
     #   goose3
     #   htmldate
     #   newspaper3k
-pytz==2024.2
+pytz==2025.2
     # via dateparser
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via newspaper3k
-queuelib==1.7.0
+queuelib==1.8.0
     # via scrapy
 rabbitmq-admin==0.2
     # via story-indexer (pyproject.toml)
-readability-lxml==0.8.1
+readability-lxml==0.8.4.1
     # via mediacloud-metadata
-regex==2024.11.6
+regex==2025.11.3
     # via
     #   dateparser
     #   nltk
-requests==2.32.3
+requests==2.32.5
     # via
     #   docker
     #   feedfinder2
@@ -200,7 +203,7 @@ requests==2.32.3
     #   rabbitmq-admin
     #   requests-file
     #   tldextract
-requests-file==2.1.0
+requests-file==3.0.1
     # via tldextract
 s3transfer==0.7.0
     # via boto3
@@ -223,7 +226,7 @@ six==1.17.0
     #   surt
     #   url-normalize
     #   warcio
-soupsieve==2.6
+soupsieve==2.8
     # via beautifulsoup4
 statsd-client==1.0.7
     # via story-indexer (pyproject.toml)
@@ -233,7 +236,7 @@ surt==0.3.1
     # via mediacloud-metadata
 tinysegmenter==0.3
     # via newspaper3k
-tld==0.13
+tld==0.13.1
     # via courlan
 tldextract==5.1.3
     # via
@@ -241,17 +244,20 @@ tldextract==5.1.3
     #   newspaper3k
     #   scrapy
     #   surt
-tomli==2.2.1
+tomli==2.3.0
     # via incremental
 tqdm==4.67.1
     # via nltk
 trafilatura==1.8.1
     # via mediacloud-metadata
-twisted==24.11.0
+twisted==25.5.0
     # via scrapy
-typing-extensions==4.12.2
-    # via twisted
-tzlocal==5.2
+typing-extensions==4.15.0
+    # via
+    #   cryptography
+    #   pyopenssl
+    #   twisted
+tzlocal==5.3.1
     # via dateparser
 url-normalize==1.4.3
     # via mediacloud-metadata
@@ -265,21 +271,20 @@ urllib3==2.0.7
     #   requests
     #   sentry-sdk
     #   trafilatura
-w3lib==2.2.1
+w3lib==2.3.1
     # via
     #   parsel
     #   scrapy
 warcio==1.7.5
     # via story-indexer (pyproject.toml)
-zope-interface==7.2
+zope-interface==8.1
     # via
     #   scrapy
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.6.0
+setuptools==80.9.0
     # via
     #   incremental
     #   scrapy
     #   supervisor
-    #   zope-interface


### PR DESCRIPTION
Ran `make upgrade` (NOTE! manual intervention needed because pip-tools 7.5.1 and pip 25.3 don't get along, and pip-tools hasn't released a version with the fix, so I manually backed down to pip 25.2, and manually ran the command to update requirements.txt)

NOTE!  `make upgrade` updated .pre-commit-config.yaml, the full effects of which may not be visible until someone changes python code!