### PR TITLE
Try falling back to RSS.domain for breadcrumbs

### DIFF
--- a/indexer/storyapp.py
+++ b/indexer/storyapp.py
@@ -90,7 +90,7 @@ class StoryMixin(AppProtocol):
         *,
         feed_id: int | None,
         source_id: int | None,
-        domain: str | None,  # canonical_domain from parser
+        domain: str | None,  # canonical_domain from parser, or from rss
         status: str,
     ) -> BreadCrumb:
         """
@@ -115,7 +115,7 @@ class StoryMixin(AppProtocol):
         crumb = self.make_crumb(
             feed_id=rss.source_feed_id,
             source_id=rss.source_source_id,
-            domain=cmd.canonical_domain,
+            domain=cmd.canonical_domain or rss.domain,
             status=status,
         )
         return crumb

--- a/indexer/workers/fetcher/rss-puller.py
+++ b/indexer/workers/fetcher/rss-puller.py
@@ -175,7 +175,7 @@ class RSSPuller(ShufflingStoryProducer):
         return self.make_crumb(
             feed_id=sj.get("feed_id"),
             source_id=sj.get("sources_id"),
-            domain=None,  # FINAL domain
+            domain=sj.get("domain"),
             status=status,
         )
 


### PR DESCRIPTION
This causes breadcrumbs generated before parser success have the domain of the initial (rss) link.

This allows queries like `status=http-403&col=domain` which shows counts by domain of URLs that got HTTP 403 (permission denied) errors.